### PR TITLE
Fix #36 - coping with shebang.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -5,6 +5,7 @@ var n = types.namedTypes;
 var b = types.builders;
 var MagicString = require("magic-string");
 var utils = require("./utils.js");
+var shebang = /^#!/
 
 exports.parse = require("./parsers/default.js").parse;
 
@@ -21,7 +22,13 @@ function getOption(options, name) {
   return defaultCompileOptions[name];
 }
 
+function commentShebang(code) {
+  if (!code) return code
+  return code.replace(shebang, "//")
+}
+
 function compile(code, options) {
+  code = commentShebang(code)
   var parse = getOption(options, "parse");
   var ast = parse(code);
   var rootPath = new types.NodePath(ast);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -5,7 +5,7 @@ var n = types.namedTypes;
 var b = types.builders;
 var MagicString = require("magic-string");
 var utils = require("./utils.js");
-var shebang = /^#!/
+var shebang = /^#!.*/;
 
 exports.parse = require("./parsers/default.js").parse;
 
@@ -22,13 +22,8 @@ function getOption(options, name) {
   return defaultCompileOptions[name];
 }
 
-function commentShebang(code) {
-  if (!code) return code
-  return code.replace(shebang, "//")
-}
-
 function compile(code, options) {
-  code = commentShebang(code)
+  code = code.replace(shebang, '');
   var parse = getOption(options, "parse");
   var ast = parse(code);
   var rootPath = new types.NodePath(ast);

--- a/test/tests.js
+++ b/test/tests.js
@@ -517,6 +517,18 @@ describe("compiler", function () {
     isCallExprStmt(ast.body[4], "console", "log");
     isCallExprStmt(ast.body[5], "module", "export");
   });
+
+  it("should not get confused by shebang", function () {
+    import { compile } from "../lib/compiler.js";
+
+    var code = [
+      "#!/usr/bin/env node -r reify",
+      'import foo from "./foo"',
+    ].join("\n");
+
+    var withShebang = compile(code).code;
+    assert.strictEqual(withShebang.indexOf('var foo'), 0)
+  });
 });
 
 describe("Node REPL", function () {


### PR DESCRIPTION
The problem identified in #36 is looks like it's caused by import/export lines getting hoisted above the shebang line during compile. 

Running:
```js
#!/usr/bin/env node -r reify
import foo from "./foo"
```
compiles to:

```js
var foo;module.import("./foo",{"default":function(v){foo=v}},0);#!/usr/bin/env node -r reify
```
...pushing the  `#!` to after the hoisted import.

~~This PR just replaces a shebang `#!` with `//`to turn it into an inline comment, which means the code remains valid and runnable. A more involved solution might prevent things from being hoisted above the shebang, but I offer this up as a starter for 10. so running:~~

This PR strips out the shebang line as that's what node core's module.js would do anyway.

Things that trying to figure this out turned up along the way: 
- Node core's `module.compile` is super cautious about stripping out shebang lines: https://github.com/nodejs/node/blob/1a47e5f409aaf89c94cfbca4a6e6a679a996aae0/lib/module.js#L511-L537
- acorn's loose mode once included a similar shebang dodging line: https://github.com/ternjs/acorn/commit/437ce2d9bee35bcccfcf9912040a418f8125fbea