### PR TITLE
`Declaration`s should become `Expression`s in exported value assignment.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -390,6 +390,15 @@ var importExportVisitor = new types.PathVisitor.fromMethodsObject({
       this.overwrite(dd.end, decl.end, this._exportDefaultSuffix, true);
 
       if (this.modifyAST) {
+        // A Function or Class declaration has become an expression on the
+        // right side of the _exportDefaultPrefix assignment above so change
+        // the AST appropriately
+        if (dd.type === "FunctionDeclaration") {
+          dd.type = "FunctionExpression";
+        } else if (dd.type === "ClassDeclaration") {
+          dd.type = "ClassExpression";
+        }
+
         path.replace(this._buildExportDefaultStatement(declPath.value));
       }
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -523,24 +523,45 @@ describe("compiler", function () {
 
   it("should transform default export declaration to expression", function () {
     import { compile } from "../lib/compiler.js";
+    
+    function parse(code) {
+      var result = compile(code, { ast: true });
+      var ast = result.ast;
 
-    var code = [
+      if (ast.type === "File") {
+        ast = ast.program;
+      }
+
+      assert.strictEqual(ast.type, "Program");
+
+      return ast;
+    }
+
+    var anonCode = [
+      "export default class {}"
+    ].join("\n");
+
+    var anonAST = parse(anonCode);
+
+    assert.strictEqual(anonAST.body.length, 1);
+
+    assert.strictEqual(
+      anonAST.body[0].expression.arguments[1].right.type,
+      "ClassExpression"
+    );
+
+    var namedCode = [
       "export default class C {}"
     ].join("\n");
 
-    var result = compile(code, { ast: true });
-    var ast = result.ast;
+    var namedAST = parse(namedCode);
 
-    if (ast.type === "File") {
-      ast = ast.program;
-    }
-
-    assert.strictEqual(ast.type, "Program");
-    assert.strictEqual(ast.body.length, 1);
+    assert.strictEqual(namedAST.body.length, 2);
 
     assert.strictEqual(
-      ast.body[0].expression.arguments[1].right.type, "ClassExpression");
-
+      anonAST.body[1].expression.arguments[1].right.type,
+      "ClassExpression"
+    );
   });
 
   it("should not get confused by shebang", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -521,6 +521,28 @@ describe("compiler", function () {
     isCallExprStmt(ast.body[5], "module", "export");
   });
 
+  it("should transform default export declaration to expression", function () {
+    import { compile } from "../lib/compiler.js";
+
+    var code = [
+      "export default class {}"
+    ].join("\n");
+
+    var result = compile(code, { ast: true });
+    var ast = result.ast;
+
+    if (ast.type === "File") {
+      ast = ast.program;
+    }
+
+    assert.strictEqual(ast.type, "Program");
+    assert.strictEqual(ast.body.length, 1);
+
+    assert.strictEqual(
+      ast.body[0].expression.arguments[1].right.type, "ClassExpression");
+
+  });
+
   it("should not get confused by shebang", function () {
     import { compile } from "../lib/compiler.js";
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -560,7 +560,7 @@ describe("compiler", function () {
 
     assert.strictEqual(
       namedAST.body[1].type,
-      "ClassExpression"
+      "ClassDeclaration"
     );
   });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -559,7 +559,7 @@ describe("compiler", function () {
     assert.strictEqual(namedAST.body.length, 2);
 
     assert.strictEqual(
-      anonAST.body[1].expression.arguments[1].right.type,
+      namedAST.body[1].expression.arguments[1].right.type,
       "ClassExpression"
     );
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -559,7 +559,7 @@ describe("compiler", function () {
     assert.strictEqual(namedAST.body.length, 2);
 
     assert.strictEqual(
-      namedAST.body[1].expression.arguments[1].right.type,
+      namedAST.body[1].type,
       "ClassExpression"
     );
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -525,7 +525,7 @@ describe("compiler", function () {
     import { compile } from "../lib/compiler.js";
 
     var code = [
-      "export default class {}"
+      "export default class C {}"
     ].join("\n");
 
     var result = compile(code, { ast: true });


### PR DESCRIPTION
This is submitted for consideration only as I'm not sure I'm qualified to speak to the far-reaching effects of this, but I can attest that problems are observed without this change as shown in the attached [Meteor issue](https://github.com/meteor/meteor#8312) and am interested in input.

Commit message included here as my best explanation, but see also [my comment on the Meteor issue](https://github.com/meteor/meteor/issues/8312#issuecomment-279367119):

----

Reify transforms default exports of `ClassDeclaration`s and
`FunctionDeclaration`s into what are essentially `ClassExpression`s and
`FunctionExpression`s.

When it comes time to use this transformed code, `acorn` appears to be
flexible when it receives a `Declaration` on the right-hand side of an
`Assignment`, but `babel` is not (it insists an `Expression`)

This change transforms the AST (when permitted by `ast: true`), to match
the assignment which is presented in the code and introduces a test to
ensure that this transformation is made.

Fixes meteor/meteor#8312

Possibly related? https://github.com/babel/babylon/issues/325