### PR TITLE
Help out bundlers.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,9 +1,13 @@
 var hasOwn = Object.prototype.hasOwnProperty;
 var assert = require("assert");
-var types = require("ast-types");
+var types = require("ast-types/fork")([
+  require("ast-types/def/esprima"),
+  require("ast-types/def/babel6")
+]);
+
 var n = types.namedTypes;
 var b = types.builders;
-var MagicString = require("magic-string");
+var MagicString = require("magic-string/dist/magic-string.cjs.js");
 var utils = require("./utils.js");
 var shebang = /^#!.*/;
 

--- a/lib/parsers/default.js
+++ b/lib/parsers/default.js
@@ -1,16 +1,16 @@
+var dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
+
 var REIFY_PARSER =
   typeof process === "object" &&
   typeof process.env === "object" &&
   process.env.REIFY_PARSER;
 
-if (REIFY_PARSER === "acorn") {
-  exports.parse = require("./acorn.js").parse;
-} else if (REIFY_PARSER === "babylon") {
-  exports.parse = require("./babylon.js").parse;
-} else if (REIFY_PARSER === "top-level") {
-  exports.parse = require("./top-level.js").parse;
+if (REIFY_PARSER === "acorn" ||
+    REIFY_PARSER === "babylon" ||
+    REIFY_PARSER === "top-level") {
+  exports.parse = require("./" + process.env.REIFY_PARSER + ".js").parse;
 } else try {
-  exports.parse = require(REIFY_PARSER);
+  exports.parse = dynRequire(REIFY_PARSER);
 } catch (e) {
-  exports.parse = require("./acorn.js").parse;
+  exports.parse = dynRequire("./acorn.js").parse;
 }

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,5 +1,6 @@
 var Entry = require("./entry.js").Entry;
 var utils = require("./utils.js");
+var dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
 
 exports.enable = function (Module) {
   var Mp = Module.prototype;
@@ -73,7 +74,7 @@ exports.enable = function (Module) {
     var countBefore = entry && entry.runCount;
     var exports = typeof module.require === "function"
       ? module.require(absoluteId)
-      : require(absoluteId);
+      : dynRequire(absoluteId);
 
     if (entry && entry.runCount === countBefore) {
       // If require(absoluteId) didn't run any setters for this entry,

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -2,6 +2,7 @@ var fs = require("fs");
 var path = require("path");
 var createHash = require("crypto").createHash;
 var compile = require("../lib/compiler.js").compile;
+var dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
 var hasOwn = Object.prototype.hasOwnProperty;
 
 // Map from absolute file paths to the package.json that governs them.
@@ -70,7 +71,7 @@ function readWithCache(info, content) {
   };
 
   if (reify && reify.parser) {
-    compileOptions.parse = require(reify.parser).parse;
+    compileOptions.parse = dynRequire(reify.parser).parse;
   };
 
   content = compile(content, compileOptions).code;

--- a/node/runtime.js
+++ b/node/runtime.js
@@ -1,4 +1,5 @@
-var Module = require("../lib/runtime.js").enable(module.constructor);
+var dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
+var Module = require("../lib/runtime.js").enable(dynRequire('module'));
 var Mp = Module.prototype;
 
 exports.Module = Module;


### PR DESCRIPTION
This PR helps bundlers out by cherry-picking and avoiding explicit id reference for conditional loads.

#### webpack.config.js
```js
'use strict'
const webpack = require('webpack')

module.exports = {
  'target': 'node',
  'plugins': [
    new webpack.optimize.UglifyJsPlugin,
    new webpack.DefinePlugin({
      'process.env.REIFY_PARSER': '"top-level"'
    })
  ]
}
```