### PR TITLE
Use `Object.create(null)` in a few more places.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -490,7 +490,7 @@ var importExportVisitor = new types.PathVisitor.fromMethodsObject({
     var dd = decl.declaration;
 
     if (dd) {
-      var specifierMap = {};
+      var specifierMap = Object.create(null);
       var addNameToMap = function (name) {
         addToSpecifierMap(specifierMap, name, name);
       };
@@ -515,7 +515,7 @@ var importExportVisitor = new types.PathVisitor.fromMethodsObject({
 
       if (decl.source) {
         if (specifierMap) {
-          var newMap = {};
+          var newMap = Object.create(null);
 
           Object.keys(specifierMap).forEach(function (exported) {
             specifierMap[exported].forEach(function (local) {
@@ -637,7 +637,7 @@ function computeSpecifierMap(specifiers) {
     }
 
     specifierMap = addToSpecifierMap(
-      specifierMap || {},
+      specifierMap || Object.create(null),
       __ported,
       local
     );


### PR DESCRIPTION
I noticed while trying to load `lodash-es` that an error occured [here](https://github.com/benjamn/reify/blob/ae4c671e76f78c200b523ed0f94343084f3c8f73/lib/compiler.js#L653-L655) because I had an identifier named `toString` and the `map` as a vanilla object and so had a `toString` method and not the array it was expecting:
```js
var locals = map[__ported] || [];
```