### PR TITLE
Use ast-types/def/babel6-core.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -2,7 +2,7 @@ var hasOwn = Object.prototype.hasOwnProperty;
 var assert = require("assert");
 var types = require("ast-types/fork")([
   require("ast-types/def/esprima"),
-  require("ast-types/def/babel6")
+  require("ast-types/def/babel6-core")
 ]);
 
 var n = types.namedTypes;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "acorn": "~4.0.5",
-    "ast-types": "^0.9.5",
+    "ast-types": "^0.9.9",
     "magic-string": "~0.19.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR circles back to use ast-types/def/babel6-core (avoids pulling in flow types).