### PR TITLE
Rename Module.prototype.import to Module.prototype.importSync.

### DIFF
--- a/BENEFITS.md
+++ b/BENEFITS.md
@@ -15,12 +15,12 @@ Benefits
   * Babel's `interopRequire{Default,Wildcard}` logic is captured by `Module.prototype.getExportByName`.
 * Does not interfere with existing `require.extensions` hooks.
 * Much simpler transform implementation as compared with other ECMASCript module compilers.
-  * `import` statements become calls to `module.import(id, setters)`
+  * `import` statements become calls to `module.importSync(id, setters)`
   * `export` statements become assignments to the `exports` object.
   * The compiler doesn't have to parse the entire file to find `import` and `export` statements.
 * Line numbers are strictly preserved.
   * No hoisting of `import` statements.
   * All `import` and `export` statements are compiled in-place.
 * No need for `Object.defineProperty`-style getters to support `export * from "..."`.
-* The `module.import(id, setters)` API is human-writable, too, if you want to implement custom update logic.
+* The `module.importSync(id, setters)` API is human-writable, too, if you want to implement custom update logic.
 * Generated code is statically analyzable, since the `exports` object is not exposed.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -415,7 +415,7 @@ var importExportVisitor = new types.PathVisitor.fromMethodsObject({
   visitExportAllDeclaration: function (path) {
     var decl = path.value;
     var parts = [
-      this.pad("module.import(", decl.start, decl.source.start),
+      this.pad("module.importSync(", decl.start, decl.source.start),
       this._getSourceString(decl),
       this.pad(
         ",{'*':function(v,k){exports[k]=v;}}," +
@@ -540,7 +540,7 @@ var importExportVisitor = new types.PathVisitor.fromMethodsObject({
           specifierMap = newMap;
         }
 
-        // Even though the compiled code uses module.import, it should
+        // Even though the compiled code uses module.importSync, it should
         // still be hoisted as an export, i.e. before actual imports.
         this.hoistExports(path, toModuleImport(
           this._getSourceString(decl),
@@ -676,7 +676,7 @@ function addToSpecifierMap(map, __ported, local) {
 }
 
 function toModuleImport(source, specifierMap, uniqueKey) {
-  var parts = ["module.import(", source];
+  var parts = ["module.importSync(", source];
   var importedNames = specifierMap && Object.keys(specifierMap);
 
   if (! importedNames || importedNames.length === 0) {

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -111,7 +111,7 @@ Ep.runGetter = function (module, name) {
   if (! hasOwn.call(exports, name) ||
       exports[name] !== value) {
     // We update module.exports[name] with the current value so that
-    // CommonJS require calls remain consistent with module.import.
+    // CommonJS require calls remain consistent with module.importSync.
     exports[name] = value;
     return true;
   }

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -5,10 +5,10 @@ var dynRequire = module.require ? module.require.bind(module) : __non_webpack_re
 exports.enable = function (Module) {
   var Mp = Module.prototype;
 
-  if (typeof Mp.import === "function" &&
+  if (typeof Mp.importSync === "function" &&
       typeof Mp.export === "function") {
-    // If the Mp.{import,export} methods have already been
-    // defined, abandon reification immediately.
+    // If the Mp.{importSync,export} methods have already been defined,
+    // abandon reification immediately.
     return Module;
   }
 
@@ -56,11 +56,11 @@ exports.enable = function (Module) {
   }
 
   // If key is provided, it will be used to identify the given setters so
-  // that they can be replaced if module.import is called again with the
+  // that they can be replaced if module.importSync is called again with the
   // same key. This avoids potential memory leaks from import declarations
   // inside loops. The compiler generates these keys automatically (and
   // deterministically) when compiling nested import declarations.
-  Mp.import = function (id, setters, key) {
+  Mp.importSync = function (id, setters, key) {
     var module = this;
     setESModule(module);
 

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -33,7 +33,7 @@ describe("babel-plugin-transform-es2015-modules-reify", function () {
     var ast = parse(code);
     delete ast.tokens;
     var result = transformFromAst(ast, code, options);
-    assert.ok(/\bmodule\.(?:import|export)\b/.test(result.code));
+    assert.ok(/\bmodule\.(?:importSync|export)\b/.test(result.code));
     return result;
   }
 

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -126,9 +126,9 @@ describe("compiler", function () {
     assert.strictEqual(ast.body.length, 6);
 
     isVarDecl(ast.body[0], ["foo"]);
-    isCallExprStmt(ast.body[1], "module", "import");
+    isCallExprStmt(ast.body[1], "module", "importSync");
     isVarDecl(ast.body[2], ["bar"]);
-    isCallExprStmt(ast.body[3], "module", "import");
+    isCallExprStmt(ast.body[3], "module", "importSync");
     isCallExprStmt(ast.body[4], "console", "log");
     isCallExprStmt(ast.body[5], "module", "export");
   });

--- a/test/export/common.js
+++ b/test/export/common.js
@@ -4,6 +4,6 @@ import { strictEqual } from "assert";
 // if there are no actual ExportDefaultDeclaration nodes.
 module.exports = "pure CommonJS";
 
-// The import statement above should have been compiled to a module.import
-// call, which sets exports.__esModule = true.
+// The import statement above should have been compiled to a
+// module.importSync call, which sets exports.__esModule = true.
 strictEqual(exports.__esModule, true);

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -25,7 +25,7 @@ describe("parent setters", function () {
     var firstCallCount = 0;
     var secondCallCount = 0;
 
-    module.import("./live.js", {
+    module.importSync("./live.js", {
       value: function (v) {
         ++firstCallCount;
         value = "first:" + v;
@@ -39,7 +39,7 @@ describe("parent setters", function () {
     assert.strictEqual(value, "first:3");
     assert.strictEqual(secondCallCount, 0);
 
-    module.import("./live.js", {
+    module.importSync("./live.js", {
       value: function (v) {
         ++secondCallCount;
         value = "second:" + v;


### PR DESCRIPTION
Because Reify controls both the runtime and the compiler, I believe this change can be made in one commit without breaking backwards compatibility, though it definitely deserves a minor version bump.

Closes #84.