### PR TITLE
Simplify logic for calling runModuleSetters for parent modules.

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -85,38 +85,25 @@ function runModuleGetters(module) {
 
 Ep.runModuleGetters = function (module) {
   var entry = this;
-  var changeCount = 0;
-
   Object.keys(entry.getters).forEach(function (name) {
-    if (entry.runGetter(module, name)) {
-      ++changeCount;
-    }
+    entry.runGetter(module, name);
   });
-
-  return changeCount;
 };
 
 // Returns true iff the getter updated module.exports with a new value.
 Ep.runGetter = function (module, name) {
-  if (! hasOwn.call(this.getters, name)) {
-    return false;
+  if (hasOwn.call(this.getters, name)) {
+    try {
+      // Update module.exports[name] with the current value so that CommonJS
+      // require calls remain consistent with module.importSync.
+      return module.exports[name] =
+        this.getters[name].call(module);
+
+    } catch (e) {
+      // If the getter threw an exception, avoid updating module.exports
+      // and return undefined.
+    }
   }
-
-  var getter = this.getters[name];
-  try {
-    var value = getter.call(module);
-  } catch (e) {}
-  var exports = module.exports;
-
-  if (! hasOwn.call(exports, name) ||
-      exports[name] !== value) {
-    // We update module.exports[name] with the current value so that
-    // CommonJS require calls remain consistent with module.importSync.
-    exports[name] = value;
-    return true;
-  }
-
-  return false;
 };
 
 // Called whenever module.exports might have changed, to trigger any
@@ -170,53 +157,22 @@ Ep.runModuleSetters = function (module) {
     }
   }
 
-  // Every three elements of this list form a (setter, value, name) triple
-  // that needs to be invoked.
-  var settersToCall = [];
-
-  // Lazily-initialized objects mapping parent module identifiers to
-  // relevant parent module objects and snapshots of their exports.
+  // Lazily-initialized object mapping parent module identifiers to parent
+  // module objects whose setters we might need to run.
   var relevantParents;
-  var parentSnapshots;
 
   // Take snapshots of setter.parent.exports for any setters that we are
   // planning to call, so that we can later determine if calling the
   // setters modified any of those exports objects.
   forEachSetter(function (setter, value, name) {
-    var parent = setter.parent;
-    parentSnapshots = parentSnapshots || Object.create(null);
-    if (! hasOwn.call(parentSnapshots, parent.id)) {
-      relevantParents = relevantParents || Object.create(null);
-      relevantParents[parent.id] = parent;
-      if (utils.isPlainObject(parent.exports)) {
-        // If parent.exports is an object, make a shallow clone of it so
-        // that we can see if it changes as a result of calling setters.
-        parentSnapshots[parent.id] = Object.assign({}, parent.exports);
-      } else {
-        // If parent.exports is not an object, the "snapshot" is just the
-        // value of parent.exports.
-        parentSnapshots[parent.id] = parent.exports;
-      }
-    }
-
-    // Push three elements at a time to avoid creating wrapper arrays for
-    // each (setter, value, name) triple. Note the i += 3 below.
-    settersToCall.push(setter, value, name);
-  });
-
-  // Now call all the setters that we decided we need to call.
-  for (var i = 0; i < settersToCall.length; i += 3) {
-    var setter = settersToCall[i];
-    var value = settersToCall[i + 1];
-    var name = settersToCall[i + 2];
+    relevantParents = relevantParents || Object.create(null);
+    relevantParents[setter.parent.id] = setter.parent;
     setter.call(module, setter.last[name] = value, name);
-  }
+  });
 
   ++entry.runCount;
 
   if (! relevantParents) {
-    // If we never called takeSnapshot, then we can avoid checking
-    // relevantParents and parentSnapshots below.
     return;
   }
 
@@ -224,21 +180,11 @@ Ep.runModuleSetters = function (module) {
   // or updated local variables that are exported by that parent module,
   // then we must re-run any setters registered by that parent module.
   Object.keys(relevantParents).forEach(function (id) {
-    var parent = relevantParents[id];
-
-    if (runModuleGetters(parent) > 0) {
-      return runModuleSetters(parent);
-    }
-
-    var exports = parent.exports;
-    var snapshot = parentSnapshots[parent.id];
-    if (utils.shallowObjEqual(exports, snapshot)) {
-      // If parent.exports have not changed since we took the snapshot,
-      // then we do not need to run the parent's setters.
-      return;
-    }
-
-    runModuleSetters(parent);
+    // What happens if relevantParents[id] === module, or if longer cycles
+    // exist in the parent chain? Thanks to our setter.last bookkeeping
+    // above, the runModuleSetters broadcast will only proceed as far as
+    // there are any actual changes to report.
+    runModuleSetters(relevantParents[id]);
   });
 };
 

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,6 +1,8 @@
-var hasOwn = Object.prototype.hasOwnProperty;
-var entryMap = Object.create(null);
-var utils = require("./utils.js");
+"use strict";
+
+const hasOwn = Object.prototype.hasOwnProperty;
+const entryMap = Object.create(null);
+const utils = require("./utils.js");
 
 function Entry(id) {
   // Same as module.id for this module.
@@ -13,7 +15,7 @@ function Entry(id) {
   this.getters = Object.create(null);
 }
 
-var Ep = Entry.prototype;
+const Ep = Entry.prototype;
 
 Entry.get = function (id) {
   return entryMap[id] || null;
@@ -23,7 +25,7 @@ Entry.getOrCreate = function (id) {
   return entryMap[id] = entryMap[id] || new Entry(id);
 };
 
-var keySalt = 0;
+let keySalt = 0;
 function makeUniqueKey() {
   return Math.random()
     .toString(36)
@@ -33,7 +35,7 @@ function makeUniqueKey() {
 }
 
 Ep.addSetters = function (parent, setters, key) {
-  var entry = this;
+  const entry = this;
 
   if (typeof key === "undefined") {
     // If no key was provided, make a new unique key that won't collide
@@ -45,8 +47,12 @@ Ep.addSetters = function (parent, setters, key) {
     key = parent.id + ":" + key;
   }
 
-  Object.keys(setters).forEach(function (name) {
-    var setter = setters[name];
+  const names = Object.keys(setters);
+  const nameCount = names.length;
+
+  for (let i = 0; i < nameCount; ++i) {
+    const name = names[i];
+    const setter = setters[name];
     if (typeof setter === "function" &&
         // Ignore any requests for the exports.__esModule property."
         name !== "__esModule") {
@@ -55,39 +61,46 @@ Ep.addSetters = function (parent, setters, key) {
        entry.setters[name] || Object.create(null)
       )[key] = setter;
     }
-  });
+  }
 };
 
 Ep.addGetters = function (getters) {
-  var entry = this;
-  Object.keys(getters).forEach(function (name) {
-    var getter = getters[name];
+  const entry = this;
+  const names = Object.keys(getters);
+  const nameCount = names.length;
+
+  for (let i = 0; i < nameCount; ++i) {
+    const name = names[i];
+    const getter = getters[name];
     if (typeof getter === "function" &&
         // Ignore any requests for the exports.__esModule property."
         name !== "__esModule") {
       // Should this throw if hasOwn.call(this.getters, name)?
       entry.getters[name] = getter;
     }
-  });
+  }
 };
 
 function runModuleSetters(module) {
-  var entry = entryMap[module.id];
+  const entry = entryMap[module.id];
   if (entry) {
     entry.runModuleSetters(module);
   }
 }
 
 function runModuleGetters(module) {
-  var entry = entryMap[module.id];
+  const entry = entryMap[module.id];
   return entry ? entry.runModuleGetters(module) : 0;
 }
 
 Ep.runModuleGetters = function (module) {
-  var entry = this;
-  Object.keys(entry.getters).forEach(function (name) {
-    entry.runGetter(module, name);
-  });
+  const entry = this;
+  const names = Object.keys(entry.getters);
+  const nameCount = names.length;
+
+  for (let i = 0; i < nameCount; ++i) {
+    entry.runGetter(module, names[i]);
+  }
 };
 
 // Returns true iff the getter updated module.exports with a new value.
@@ -109,8 +122,8 @@ Ep.runGetter = function (module, name) {
 // Called whenever module.exports might have changed, to trigger any
 // setters associated with the newly exported values.
 Ep.runModuleSetters = function (module) {
-  var entry = this;
-  var names = Object.keys(entry.setters);
+  const entry = this;
+  const names = Object.keys(entry.setters);
 
   // Make sure module.exports is up to date before we call
   // module.getExportByName(name).
@@ -126,17 +139,27 @@ Ep.runModuleSetters = function (module) {
   // setters itself, only the given callback.
   function forEachSetter(callback, context) {
     names.forEach(function (name) {
-      var setters = entry.setters[name];
-      Object.keys(setters).forEach(function (key) {
-        var value = module.getExportByName(name);
+      const setters = entry.setters[name];
+      const keys = Object.keys(setters);
+      const keyCount = keys.length;
+
+      for (let k = 0; k < keyCount; ++k) {
+        const key = keys[k];
+        const value = module.getExportByName(name);
+
         if (name === "*") {
-          Object.keys(value).forEach(function (name) {
-            call(setters[key], value[name], name);
-          });
+          const valueNames = Object.keys(value);
+          const valueNameCount = valueNames.length;
+
+          for (let v = 0; v < valueNameCount; ++v) {
+            const valueName = valueNames[v];
+            call(setters[key], value[valueName], valueName);
+          }
+
         } else {
           call(setters[key], value, name);
         }
-      });
+      }
     });
 
     function call(setter, value, name) {
@@ -159,7 +182,7 @@ Ep.runModuleSetters = function (module) {
 
   // Lazily-initialized object mapping parent module identifiers to parent
   // module objects whose setters we might need to run.
-  var relevantParents;
+  let relevantParents;
 
   // Take snapshots of setter.parent.exports for any setters that we are
   // planning to call, so that we can later determine if calling the
@@ -179,13 +202,17 @@ Ep.runModuleSetters = function (module) {
   // If any of the setters updated the module.exports of a parent module,
   // or updated local variables that are exported by that parent module,
   // then we must re-run any setters registered by that parent module.
-  Object.keys(relevantParents).forEach(function (id) {
-    // What happens if relevantParents[id] === module, or if longer cycles
-    // exist in the parent chain? Thanks to our setter.last bookkeeping
-    // above, the runModuleSetters broadcast will only proceed as far as
-    // there are any actual changes to report.
-    runModuleSetters(relevantParents[id]);
-  });
+
+  const parentIDs = Object.keys(relevantParents);
+  const parentIDCount = parentIDs.length;
+
+  for (let i = 0; i < parentIDCount; ++i) {
+    // What happens if relevantParents[parentIDs[id]] === module, or if
+    // longer cycles exist in the parent chain? Thanks to our setter.last
+    // bookkeeping above, the runModuleSetters broadcast will only proceed
+    // as far as there are any actual changes to report.
+    runModuleSetters(relevantParents[parentIDs[i]]);
+  }
 };
 
 exports.Entry = Entry;


### PR DESCRIPTION
When @jdalton tells you he can't make sense of your code, it's probably worth simplifying.

Trying to detect whether setters modified `module.exports` objects of any parent modules was never strictly necessary, since it was always safe to call `runModuleSetters` blindly and trust the `setter.last` cache to prevent the broadcast from falling into an infinite loop.

Whatever the performance benefits of avoiding calling `runModuleSetters` might have been, the benefits of not taking snapshots of parent `module.exports` objects are probably at least as significant.