### PR TITLE
Use Object.create(null) for namespace import value.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -622,7 +622,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
       // ExportNamespaceSpecifier. We initialize the target object as the
       // argument to a .bind method call on the setter function, so that
       // we can refer to it as `this` inside the setter function.
-      bind = ".bind(" + local + "={})";
+      bind = ".bind(" + local + "=Object.create(null))";
       local = "this";
 
       // When the imported name is "*", the setter function may be called


### PR DESCRIPTION
This just makes the value at least be `Object.create(null)`. It doesn't address the `Object.seal` or `const` use yet.