### PR TITLE
Remove unneeded `dynRequire` use from lib/runtime.

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,11 +1,6 @@
 var hasOwn = Object.prototype.hasOwnProperty;
 var Entry = require("./entry.js").Entry;
 var utils = require("./utils.js");
-var dynRequire = module.require ? function require(id) {
-  // Infuriatingly, this code may have to run in environments that do not
-  // have Function.prototype.bind (cough cough PhantomJS).
-  return module.require(id);
-} : __non_webpack_require__;
 
 exports.enable = function (Module) {
   var Mp = Module.prototype;
@@ -84,9 +79,7 @@ exports.enable = function (Module) {
     }
 
     var countBefore = entry && entry.runCount;
-    var exports = typeof module.require === "function"
-      ? module.require(absoluteId)
-      : dynRequire(absoluteId);
+    var exports = module.require(absoluteId);
 
     if (entry && entry.runCount === countBefore) {
       // If require(absoluteId) didn't run any setters for this entry,


### PR DESCRIPTION
This PR removes unneeded `dynRequire` use from lib/runtime.