### PR TITLE
Allow setting compiler options in node/index.js.

### DIFF
--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -5,6 +5,12 @@ const compiler = require("./caching-compiler.js");
 const Module = require("./runtime.js").Module;
 const Mp = Module.prototype;
 
+let overrideCompileOptions = {};
+
+module.exports = exports = (options) => {
+  overrideCompileOptions = Object.assign({}, options);
+};
+
 // Override Module.prototype._compile to compile any code that will be
 // evaluated as a module.
 const _compile = Mp._compile;
@@ -12,7 +18,7 @@ if (! _compile.reified) {
   (Mp._compile = function (content, filename) {
     return _compile.call(
       this,
-      compiler.compile(content, {
+      compiler.compile(content, Object.assign({
         filename: filename,
         makeCacheKey() {
           const stat = compiler.statOrNull(filename);
@@ -22,7 +28,7 @@ if (! _compile.reified) {
             mtime: stat.mtime.getTime()
           };
         }
-      }),
+      }, overrideCompileOptions)),
       filename
     );
   }).reified = _compile;

--- a/node/index.js
+++ b/node/index.js
@@ -1,2 +1,4 @@
+"use strict";
+
 require("./runtime.js");
-require("./compile-hook.js");
+module.exports = exports = require("./compile-hook.js");


### PR DESCRIPTION
This PR is a take at allowing the node/index.js to accept compiler option overrides.

It allows:
```js
require("reify/node")({
  someSetting: true,
  otherSetting: "path/to/smth"
})
```

The interface could be different though, this is just an initial take on it.

Related to #91.