### PR TITLE
Use a cache key involving filename and mtime when possible.

### DIFF
--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -57,8 +57,11 @@ function compileWithCache(pkgInfo, content, options) {
   const json = pkgInfo && pkgInfo.json;
   const reify = json && json.reify;
 
-  const cacheFilename =
-    getCacheFilename(options.cacheKey || content, reify);
+  const cacheKey = typeof options.makeCacheKey === "function"
+    ? options.makeCacheKey()
+    : options.cacheKey || content;
+
+  const cacheFilename = getCacheFilename(cacheKey, reify);
 
   const absCachePath = typeof pkgInfo.cacheDir === "string" &&
     path.join(pkgInfo.cacheDir, cacheFilename);

--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -10,15 +10,17 @@ const Mp = Module.prototype;
 const _compile = Mp._compile;
 if (! _compile.reified) {
   (Mp._compile = function (content, filename) {
-    const stat = compiler.statOrNull(filename);
     return _compile.call(
       this,
       compiler.compile(content, {
         filename: filename,
-        cacheKey: stat && {
-          source: "Module.prototype._compile",
-          filename: filename,
-          mtime: stat.mtime.getTime()
+        makeCacheKey() {
+          const stat = compiler.statOrNull(filename);
+          return stat && {
+            source: "Module.prototype._compile",
+            filename: filename,
+            mtime: stat.mtime.getTime()
+          };
         }
       }),
       filename

--- a/repl/index.js
+++ b/repl/index.js
@@ -15,13 +15,18 @@ function wrap(name, optionsArgIndex) {
 
   vm[name] = function (code) {
     const options = arguments[optionsArgIndex];
-    const filename = options && options.filename;
-    const args = [compile(code, filename)];
+    const compileOptions = Object.create(null);
+    if (options && typeof options.filename === "string") {
+      compileOptions.filename = options.filename;
+    }
+
+    const args = [compile(code, compileOptions)];
     const argsCount = arguments.length;
 
     for (let i = 1; i < argsCount; ++i) {
       args.push(arguments[i]);
     }
+
     return method.apply(vm, args);
   };
 


### PR DESCRIPTION
The `vm.*` wrappers registered by [`repl/index.js`](https://github.com/benjamn/reify/blob/master/repl/index.js) still just hash the contents, so those cache entries should no longer collide with the ones used by `Module.prototype._compile`.

Part of #90.
Closes #98.