### PR TITLE
Use more ES6 in lib.

### DIFF
--- a/lib/assignment-visitor.js
+++ b/lib/assignment-visitor.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var utils = require("./utils.js");
-var hasOwn = Object.prototype.hasOwnProperty;
-var Visitor = require("./visitor.js");
+const utils = require("./utils.js");
+const hasOwn = Object.prototype.hasOwnProperty;
+const Visitor = require("./visitor.js");
 
 function AssignmentVisitor() {
   Visitor.call(this);
@@ -31,7 +31,7 @@ AVp.visitUpdateExpression = function (path) {
 AVp.visitCallExpression = function (path) {
   this.visitChildren(path);
 
-  var callee = path.getValue().callee;
+  const callee = path.getValue().callee;
   if (callee.type === "Identifier" &&
       callee.name === "eval") {
     this._wrap(path);
@@ -41,19 +41,21 @@ AVp.visitCallExpression = function (path) {
 AVp._assignmentHelper = function (path, childName) {
   this.visitChildren(path);
 
-  var child = path.getValue()[childName];
-  var assignedNames = utils.getNamesFromPattern(child);
-  var modifiesExport = assignedNames.some(function (name) {
-    return hasOwn.call(this.exportedLocalNames, name);
-  }, this);
+  const child = path.getValue()[childName];
+  const assignedNames = utils.getNamesFromPattern(child);
+  const nameCount = assignedNames.length;
 
-  if (modifiesExport) {
-    this._wrap(path);
+  // Wrap assignments to exported identifiers with `module.runModuleSetters`.
+  for (let i = 0; i < nameCount; ++i) {
+    if (hasOwn.call(this.exportedLocalNames, assignedNames[i])) {
+      this._wrap(path);
+      break;
+    }
   }
 };
 
 AVp._wrap = function (path) {
-  var value = path.getValue();
+  const value = path.getValue();
 
   if (this.magicString) {
     this.magicString.prependRight(

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,21 +1,23 @@
-var hasOwn = Object.prototype.hasOwnProperty;
-var assert = require("assert");
-var FastPath = require("./fast-path.js");
-var utils = require("./utils.js");
-var shebangRegExp = /^#!.*/;
-var importExportRegExp = /\b(?:im|ex)port\b/;
-var getOption = require("./options.js").get;
+"use strict";
+
+const hasOwn = Object.prototype.hasOwnProperty;
+const assert = require("assert");
+const FastPath = require("./fast-path.js");
+const utils = require("./utils.js");
+const shebangRegExp = /^#!.*/;
+const importExportRegExp = /\b(?:im|ex)port\b/;
+const getOption = require("./options.js").get;
 
 exports.parse = require("./parsers/default.js").parse;
 
 function compile(code, options) {
-  var parse = getOption(options, "parse");
+  const parse = getOption(options, "parse");
   code = code.replace(shebangRegExp, "");
 
   if (! importExportRegExp.test(code)) {
     options.identical = true;
 
-    var result = { code: code };
+    const result = { code };
 
     if (getOption(options, "ast")) {
       // To take full advantage of identity checking, you should probably
@@ -26,12 +28,12 @@ function compile(code, options) {
     return result;
   }
 
-  var ast = parse(code);
-  var rootPath = FastPath.from(ast);
+  const ast = parse(code);
+  const rootPath = FastPath.from(ast);
 
   importExportVisitor.visit(rootPath, code, options);
 
-  var magicString = importExportVisitor.magicString;
+  const magicString = importExportVisitor.magicString;
 
   assignmentVisitor.visit(rootPath, {
     magicString: magicString,
@@ -41,7 +43,7 @@ function compile(code, options) {
 
   importExportVisitor.finalizeHoisting();
 
-  var result = {
+  const result = {
     code: magicString.toString()
   };
 
@@ -57,8 +59,8 @@ function compile(code, options) {
 exports.compile = compile;
 
 function transform(ast, options) {
-  var rootPath = FastPath.from(ast);
-  var importExportOptions = Object.assign({}, options);
+  const rootPath = FastPath.from(ast);
+  const importExportOptions = Object.assign({}, options);
 
   // Essential so that the AST will be modified.
   importExportOptions.ast = true;
@@ -81,8 +83,8 @@ function transform(ast, options) {
 
 exports.transform = transform;
 
-var IEV = require("./import-export-visitor.js");
-var importExportVisitor = new IEV;
+const IEV = require("./import-export-visitor.js");
+const importExportVisitor = new IEV;
 
-var AV = require("./assignment-visitor.js");
-var assignmentVisitor = new AV;
+const AV = require("./assignment-visitor.js");
+const assignmentVisitor = new AV;

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -138,21 +138,24 @@ Ep.runModuleSetters = function (module) {
   // that needs to be called. Note that forEachSetter does not call any
   // setters itself, only the given callback.
   function forEachSetter(callback, context) {
-    names.forEach(function (name) {
+    var nameCount = names.length;
+
+    for (var i = 0; i < nameCount; ++i) {
+      var name = names[i];
       var setters = entry.setters[name];
       var keys = Object.keys(setters);
       var keyCount = keys.length;
 
-      for (var k = 0; k < keyCount; ++k) {
-        var key = keys[k];
+      for (var j = 0; j < keyCount; ++j) {
+        var key = keys[j];
         var value = module.getExportByName(name);
 
         if (name === "*") {
           var valueNames = Object.keys(value);
           var valueNameCount = valueNames.length;
 
-          for (var v = 0; v < valueNameCount; ++v) {
-            var valueName = valueNames[v];
+          for (var k = 0; k < valueNameCount; ++k) {
+            var valueName = valueNames[k];
             call(setters[key], value[valueName], valueName);
           }
 
@@ -160,7 +163,7 @@ Ep.runModuleSetters = function (module) {
           call(setters[key], value, name);
         }
       }
-    });
+    }
 
     function call(setter, value, name) {
       if (name === "__esModule") {

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const assert = require("assert");
-const undefined = void 0;
 
 // A simplified version of the FastPath AST traversal abstraction used by
 // Recast: https://github.com/benjamn/recast/blob/master/lib/fast-path.js
@@ -118,14 +117,16 @@ FPp.call = function call(callback/*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
-  const argc = arguments.length;
-  for (let i = 1; i < argc; ++i) {
+  const argCount = arguments.length;
+
+  for (let i = 1; i < argCount; ++i) {
     const name = arguments[i];
     value = value[name];
     s.push(name, value);
   }
   const result = callback(this);
   s.length = origLen;
+
   return result;
 };
 
@@ -137,9 +138,9 @@ FPp.each = function each(callback/*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
   const value = s[origLen - 1];
-  const argc = arguments.length;
+  const argCount = arguments.length;
 
-  for (let i = 1; i < argc; ++i) {
+  for (let i = 1; i < argCount; ++i) {
     const name = arguments[i];
     value = value[name];
     s.push(name, value);
@@ -166,9 +167,9 @@ FPp.some = function some(callback/*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
   const value = s[origLen - 1];
-  const argc = arguments.length;
+  const argCount = arguments.length;
 
-  for (let i = 1; i < argc; ++i) {
+  for (let i = 1; i < argCount; ++i) {
     const name = arguments[i];
     value = value[name];
     s.push(name, value);

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var assert = require("assert");
-var MagicString = require("magic-string/dist/magic-string.cjs.js");
-var utils = require("./utils.js");
-var Visitor = require("./visitor.js");
-var getOption = require("./options.js").get;
+const assert = require("assert");
+const MagicString = require("magic-string/dist/magic-string.cjs.js");
+const utils = require("./utils.js");
+const Visitor = require("./visitor.js");
+const getOption = require("./options.js").get;
 
-var hasOwn = Object.prototype.hasOwnProperty;
+const hasOwn = Object.prototype.hasOwnProperty;
 
 function ImportExportVisitor() {
   Visitor.call(this);
@@ -14,7 +14,7 @@ function ImportExportVisitor() {
 
 module.exports = ImportExportVisitor;
 
-var IEVp = ImportExportVisitor.prototype =
+const IEVp = ImportExportVisitor.prototype =
   Object.create(Visitor.prototype);
 IEVp.constructor = ImportExportVisitor;
 
@@ -44,9 +44,9 @@ IEVp.makeUniqueKey = function () {
 
 IEVp.pad = function (newCode, oldStart, oldEnd) {
   if (this.code) {
-    var oldLines = this.code.slice(oldStart, oldEnd).split("\n");
-    var newLines = newCode.split("\n");
-    var diff = oldLines.length - newLines.length;
+    const oldLines = this.code.slice(oldStart, oldEnd).split("\n");
+    const newLines = newCode.split("\n");
+    let diff = oldLines.length - newLines.length;
     while (diff --> 0) {
       newLines.push("");
     }
@@ -64,7 +64,7 @@ IEVp.overwrite = function (oldStart, oldEnd, newCode, trailing) {
   assert.strictEqual(typeof oldEnd, "number");
   assert.strictEqual(typeof newCode, "string");
 
-  var padded = this.pad(newCode, oldStart, oldEnd);
+  const padded = this.pad(newCode, oldStart, oldEnd);
 
   if (oldStart === oldEnd) {
     if (padded === "") {
@@ -142,7 +142,10 @@ IEVp.getBlockBodyInfo = function (path) {
   // "use strict", which may depend on occurring at the beginning of
   // their enclosing scopes.
   let insertNodeIndex = 0;
-  body.some(function (stmt, i) {
+  const stmtCount = body.length;
+
+  for (let i = 0; i < stmtCount; ++i) {
+    const stmt = body[i];
     if (stmt.type === "ExpressionStatement") {
       const expr = stmt.expression;
       if (expr.type === "StringLiteral" ||
@@ -150,19 +153,21 @@ IEVp.getBlockBodyInfo = function (path) {
            typeof expr.value === "string")) {
         insertCharIndex = stmt.end;
         insertNodeIndex = i + 1;
-        return false;
+        continue;
       }
     }
-    return true;
-  });
+    break;
+  }
 
   // Babylon represents directives like "use strict" with a .directives
   // array property on the parent node.
-  var directives = parent.directives;
+  const directives = parent.directives;
   if (directives) {
-    directives.forEach(function (directive) {
-      insertCharIndex = Math.max(directive.end, insertCharIndex);
-    });
+    const directiveCount = directives.length;
+
+    for (let i = 0; i < directiveCount; ++i) {
+      insertCharIndex = Math.max(directives[i].end, insertCharIndex);
+    }
   }
 
   const bibn = parent._bodyInfoByName =
@@ -193,15 +198,22 @@ IEVp.hoistExports = function (exportDeclPath, mapOrString, childName) {
   const bodyInfo = this.getBlockBodyInfo(exportDeclPath);
 
   if (utils.isPlainObject(mapOrString)) {
-    Object.keys(mapOrString).forEach(function (exported) {
-      mapOrString[exported].forEach(function (local) {
+    const keys = Object.keys(mapOrString);
+    const keyCount = keys.length;
+
+    for (let i = 0; i < keyCount; ++i) {
+      const exported = keys[i];
+      const locals = mapOrString[exported];
+      const localCount = locals.length;
+
+      for (let j = 0; j < localCount; ++j) {
         addToSpecifierMap(
           bodyInfo.hoistedExportsMap,
           exported,
-          local
+          locals[j]
         );
-      });
-    });
+      }
+    }
 
   } else if (typeof mapOrString === "string") {
     bodyInfo.hoistedExportsString += mapOrString;
@@ -260,7 +272,10 @@ IEVp.preserveChild = function (path, childName) {
 };
 
 IEVp.finalizeHoisting = function () {
-  this.bodyInfos.forEach(function (bodyInfo) {
+  const infoCount = this.bodyInfos.length;
+
+  for (let i = 0; i < infoCount; ++i) {
+    const bodyInfo = this.bodyInfos[i];
     const parts = [];
 
     const namedExports = toModuleExport(bodyInfo.hoistedExportsMap);
@@ -303,7 +318,7 @@ IEVp.finalizeHoisting = function () {
     delete bodyInfo.hoistedExportsMap;
     delete bodyInfo.hoistedExportsString;
     delete bodyInfo.hoistedImportsString;
-  }, this);
+  }
 
   // Just in case we call finalizeHoisting again, don't hoist anything.
   this.bodyInfos.length = 0;
@@ -345,13 +360,17 @@ IEVp.visitImportDeclaration = function (path) {
   if (decl.specifiers.length > 0) {
     parts.push(this.generateLetDeclarations ? "let " : "var ");
 
-    decl.specifiers.forEach(function (s, i) {
-      const isLast = i === decl.specifiers.length - 1;
+    const specifierCount = decl.specifiers.length;
+    const lastIndex = specifierCount - 1;
+
+    for (let i = 0; i < specifierCount; ++i) {
+      const s = decl.specifiers[i];
+      const isLast = i === lastIndex;
       parts.push(
         s.local.name,
         isLast ? ";" : ","
       );
-    });
+    }
   }
 
   parts.push(toModuleImport(
@@ -466,9 +485,16 @@ IEVp.visitExportNamedDeclaration = function (path) {
                   dd.type === "FunctionDeclaration")) {
       addNameToMap(dd.id.name);
     } else if (dd.type === "VariableDeclaration") {
-      dd.declarations.forEach(function (ddd) {
-        utils.getNamesFromPattern(ddd.id).forEach(addNameToMap);
-      });
+      const ddCount = dd.declarations.length;
+
+      for (let i = 0; i < ddCount; ++i) {
+        const names = utils.getNamesFromPattern(dd.declarations[i].id);
+        const nameCount = names.length;
+
+        for (let j = 0; j < nameCount; ++j) {
+          addNameToMap(names[j]);
+        }
+      }
     }
 
     this.hoistExports(path, specifierMap, "declaration");
@@ -483,12 +509,18 @@ IEVp.visitExportNamedDeclaration = function (path) {
     if (decl.source) {
       if (specifierMap) {
         const newMap = Object.create(null);
+        const keys = Object.keys(specifierMap);
+        const keyCount = keys.length;
 
-        Object.keys(specifierMap).forEach(function (exported) {
-          specifierMap[exported].forEach(function (local) {
-            addToSpecifierMap(newMap, local, "exports." + exported);
-          });
-        });
+        for (let i = 0; i < keyCount; ++i) {
+          const exported = keys[i];
+          const locals = specifierMap[exported];
+          const localCount = locals.length;
+
+          for (let j = 0; j < localCount; ++j) {
+            addToSpecifierMap(newMap, locals[j], "exports." + exported);
+          }
+        }
 
         specifierMap = newMap;
       }
@@ -528,16 +560,23 @@ IEVp._getSourceString = function (decl) {
 IEVp.addExportedLocalNames = function (specifierMap) {
   if (specifierMap) {
     const exportedLocalNames = this.exportedLocalNames;
-    Object.keys(specifierMap).forEach(function (exported) {
-      specifierMap[exported].forEach(function (local) {
+    const keys = Object.keys(specifierMap);
+    const keyCount = keys.length;
+
+    for (let i = 0; i < keyCount; ++i) {
+      const exported = keys[i];
+      const locals = specifierMap[exported];
+      const localCount = locals.length;
+
+      for (let j = 0; j < localCount; ++j) {
         // It's tempting to record the exported name as the value here,
         // instead of true, but there can be more than one exported name
         // per local variable, and we don't actually use the exported
         // name(s) in the assignmentVisitor, so it's not worth the added
         // complexity of tracking unused information.
-        exportedLocalNames[local] = true;
-      });
-    });
+        exportedLocalNames[locals[j]] = true;
+      }
+    }
   }
 };
 
@@ -545,8 +584,11 @@ IEVp.addExportedLocalNames = function (specifierMap) {
 // names bound to those identifiers.
 function computeSpecifierMap(specifiers) {
   let specifierMap;
+  const specifierCount = specifiers.length;
 
-  specifiers.forEach(function (s) {
+  for (let i = 0; i < specifierCount; ++i) {
+    const s = specifiers[i];
+
     const local =
       s.type === "ExportDefaultSpecifier" ? "default" :
       s.type === "ExportNamespaceSpecifier" ? "*" :
@@ -571,7 +613,7 @@ function computeSpecifierMap(specifiers) {
       __ported,
       local
     );
-  });
+  }
 
   return specifierMap;
 }
@@ -593,17 +635,21 @@ function addToSpecifierMap(map, __ported, local) {
 
 function toModuleImport(source, specifierMap, uniqueKey) {
   const parts = ["module.importSync(", source];
-  const importedNames = specifierMap && Object.keys(specifierMap);
+  const importedNames = specifierMap ? Object.keys(specifierMap) : null;
+  const nameCount = importedNames ? importedNames.length : 0;
 
-  if (! importedNames || importedNames.length === 0) {
+  if (nameCount === 0) {
     parts.push(");");
     return parts.join("");
   }
 
   parts.push(",{");
 
-  importedNames.forEach(function (imported, i) {
-    const isLast = i === importedNames.length - 1;
+  const lastIndex = nameCount - 1;
+
+  for (let i = 0; i < nameCount; ++i) {
+    const imported = importedNames[i];
+    const isLast = i === lastIndex;
     const locals = specifierMap[imported];
     const valueParam = safeParam("v", locals);
     let bind = "";
@@ -651,7 +697,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
     if (! isLast) {
       parts.push(",");
     }
-  });
+  }
 
   parts.push("}," + uniqueKey + ");");
 
@@ -666,17 +712,19 @@ function safeParam(param, locals) {
 }
 
 function toModuleExport(specifierMap) {
-  const exportedKeys = specifierMap && Object.keys(specifierMap);
+  const exportedKeys = specifierMap ? Object.keys(specifierMap) : null;
+  const keyCount = exportedKeys ? exportedKeys.length : 0;
 
-  if (! exportedKeys ||
-      exportedKeys.length === 0) {
+  if (keyCount === 0) {
     return "";
   }
 
   const parts = ["module.export({"];
+  const lastIndex = keyCount - 1;
 
-  exportedKeys.forEach(function (exported, i) {
-    const isLast = i === exportedKeys.length - 1;
+  for (let i = 0; i < keyCount; ++i) {
+    const exported = exportedKeys[i];
+    const isLast = i === lastIndex;
     const locals = specifierMap[exported];
 
     assert.strictEqual(locals.length, 1);
@@ -687,7 +735,7 @@ function toModuleExport(specifierMap) {
       locals[0],
       isLast ? "}" : "},"
     );
-  });
+  }
 
   parts.push("});");
 

--- a/lib/parsers/acorn.js
+++ b/lib/parsers/acorn.js
@@ -1,4 +1,6 @@
-var acorn = require("acorn");
+"use strict";
+
+const acorn = require("acorn");
 
 exports.options = {
   ecmaVersion: 8,
@@ -9,7 +11,7 @@ exports.options = {
 };
 
 function acornParse(code) {
-  var parser = new acorn.Parser(exports.options, code);
+  const parser = new acorn.Parser(exports.options, code);
 
   // It's not Reify's job to enforce strictness.
   parser.strict = false;

--- a/lib/parsers/babylon.js
+++ b/lib/parsers/babylon.js
@@ -1,4 +1,6 @@
-var babylon = require("babylon");
+"use strict";
+
+const babylon = require("babylon");
 
 exports.options = {
   sourceType: "module",

--- a/lib/parsers/default.js
+++ b/lib/parsers/default.js
@@ -1,6 +1,8 @@
-var dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
+"use strict";
 
-var REIFY_PARSER =
+const dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
+
+const REIFY_PARSER =
   typeof process === "object" &&
   typeof process.env === "object" &&
   process.env.REIFY_PARSER;

--- a/lib/parsers/top-level.js
+++ b/lib/parsers/top-level.js
@@ -1,4 +1,6 @@
-var acorn = require("acorn");
+"use strict";
+
+const acorn = require("acorn");
 
 exports.options = {
   ecmaVersion: 8,
@@ -10,8 +12,8 @@ exports.options = {
 
 // Inspired by https://github.com/RReverser/esmod/blob/master/index.js:
 function quickParseBlock() {
-  var node = this.startNode();
-  var length = this.context.length;
+  const node = this.startNode();
+  const length = this.context.length;
 
   do this.next();
   while (this.context.length >= length);
@@ -23,7 +25,7 @@ function quickParseBlock() {
 }
 
 function topLevelParse(code) {
-  var parser = new acorn.Parser(exports.options, code);
+  const parser = new acorn.Parser(exports.options, code);
 
   // Override the Parser's parseBlock method.
   parser.parseBlock = quickParseBlock;

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var hasOwn = Object.prototype.hasOwnProperty;
 var Entry = require("./entry.js").Entry;
 var utils = require("./utils.js");

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,9 @@
+"use strict";
+
 var objToStr = Object.prototype.toString;
-var objStr = objToStr.call({});
 
 exports.isPlainObject = function (value) {
-  return objToStr.call(value) === objStr;
+  return objToStr.call(value) === "[object Object]";
 };
 
 exports.getNamesFromPattern = function (pattern) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -7,9 +7,23 @@ const underscoreCode = "_".charCodeAt(0);
 // https://github.com/benjamn/ast-types/blob/master/lib/path-visitor.js
 
 function Visitor() {
-  this.visit = this.visit.bind(this);
-  this.visitWithoutReset = this.visitWithoutReset.bind(this);
-  this.visitChildren = this.visitChildren.bind(this);
+  const that = this;
+  const visit = this.visit;
+  const visitWithoutReset = this.visitWithoutReset;
+  const visitChildren = this.visitChildren;
+
+  // Avoid slower `Function#bind` for Node < 7.
+  this.visit = function () {
+    visit.apply(that, arguments);
+  };
+
+  this.visitWithoutReset = function (path) {
+    visitWithoutReset.call(that, path);
+  };
+
+  this.visitChildren = function (path) {
+    visitChildren.call(that, path);
+  };
 }
 
 module.exports = Visitor;


### PR DESCRIPTION
This goes through the lib files and modernizes them where safe to do so. It also avoids slower ES5 array built-in use and unneeded slower binds.