### PR TITLE
Fix some const and function name assignment bugs.

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -13,7 +13,7 @@ const FPp = FastPath.prototype;
 module.exports = FastPath;
 
 // Static convenience function for coercing a value to a FastPath.
-FastPath.from = function(obj) {
+FastPath.from = function (obj) {
   return obj instanceof FastPath
     // Return a defensive copy of any existing FastPath instances.
     ? obj.copy()
@@ -21,15 +21,15 @@ FastPath.from = function(obj) {
     : new FastPath(obj);
 };
 
-FPp.copy = function copy() {
-  const copy = Object.create(FastPath.prototype);
-  copy.stack = this.stack.slice(0);
-  return copy;
+FPp.copy = function () {
+  const cp = Object.create(FastPath.prototype);
+  cp.stack = this.stack.slice(0);
+  return cp;
 };
 
 // The name of the current property is always the penultimate element of
 // this.stack, and always a String.
-FPp.getName = function getName() {
+FPp.getName = function () {
   const s = this.stack;
   const len = s.length;
   if (len > 1) {
@@ -42,12 +42,12 @@ FPp.getName = function getName() {
 
 // The value of the current property is always the final element of
 // this.stack.
-FPp.getValue = function getValue() {
+FPp.getValue = function () {
   const s = this.stack;
   return s[s.length - 1];
 };
 
-FPp.getContainer = function getContainer() {
+FPp.getContainer = function () {
   const s = this.stack;
   const len = s.length;
   if (len > 2) {
@@ -98,12 +98,12 @@ FPp.valueIsNode = function () {
   return isNodeLike(this.getValue());
 };
 
-FPp.getNode = function getNode(count) {
+FPp.getNode = function (count) {
   if (count === undefined) count = 0;
   return getNodeHelper(this, count);
 };
 
-FPp.getParentNode = function getParentNode(count) {
+FPp.getParentNode = function (count) {
   if (count === undefined) count = 0;
   return getNodeHelper(this, count + 1);
 };
@@ -113,11 +113,11 @@ FPp.getParentNode = function getParentNode(count) {
 // reference to this (modified) FastPath object. Note that the stack will
 // be restored to its original state after the callback is finished, so it
 // is probably a mistake to retain a reference to the path.
-FPp.call = function call(callback/*, name1, name2, ... */) {
+FPp.call = function (callback/*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
-  let value = s[origLen - 1];
   const argCount = arguments.length;
+  let value = s[origLen - 1];
 
   for (let i = 1; i < argCount; ++i) {
     const name = arguments[i];
@@ -134,11 +134,11 @@ FPp.call = function call(callback/*, name1, name2, ... */) {
 // accessing this.getValue()[name1][name2]... should be array-like. The
 // callback will be called with a reference to this path object for each
 // element of the array.
-FPp.each = function each(callback/*, name1, name2, ... */) {
+FPp.each = function (callback/*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
-  const value = s[origLen - 1];
   const argCount = arguments.length;
+  let value = s[origLen - 1];
 
   for (let i = 1; i < argCount; ++i) {
     const name = arguments[i];
@@ -163,11 +163,11 @@ FPp.each = function each(callback/*, name1, name2, ... */) {
 // accessing this.getValue()[name1][name2]... should be array-like. The
 // callback will be called with a reference to this path object for each
 // element of the array.
-FPp.some = function some(callback/*, name1, name2, ... */) {
+FPp.some = function (callback/*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
-  const value = s[origLen - 1];
   const argCount = arguments.length;
+  let value = s[origLen - 1];
 
   for (let i = 1; i < argCount; ++i) {
     const name = arguments[i];


### PR DESCRIPTION
I decided to try to use babel on reify's bundle (experimenting with smth) and noticed build fails related to assignments to const values. 