### PR TITLE
Defer loading parsers/default.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -8,8 +8,6 @@ const shebangRegExp = /^#!.*/;
 const importExportRegExp = /\b(?:im|ex)port\b/;
 const getOption = require("./options.js").get;
 
-exports.parse = require("./parsers/default.js").parse;
-
 function compile(code, options) {
   const parse = getOption(options, "parse");
   code = code.replace(shebangRegExp, "");

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,9 +3,11 @@
 const hasOwn = Object.prototype.hasOwnProperty;
 
 const defaultCompileOptions = {
+  ast: false,
   generateLetDeclarations: false,
-  parse: require("./parsers/default.js").parse,
-  ast: false
+  get parse () {
+    return require("./parsers/default.js").parse;
+  }
 };
 
 exports.get = function (options, name) {


### PR DESCRIPTION
I noticed the acorn parser was loading even though I was only specifying the top-level.