### PR TITLE
Add .mjs support.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,7 +12,7 @@ function compile(code, options) {
   const parse = getOption(options, "parse");
   code = code.replace(shebangRegExp, "");
 
-  if (! importExportRegExp.test(code)) {
+  if (! getOption(options, "force") &&  ! importExportRegExp.test(code)) {
     options.identical = true;
 
     const result = { code };

--- a/lib/options.js
+++ b/lib/options.js
@@ -4,6 +4,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 
 const defaultCompileOptions = {
   ast: false,
+  force: false,
   generateLetDeclarations: false,
   get parse () {
     return require("./parsers/default.js").parse;

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -79,8 +79,12 @@ function compileWithCache(pkgInfo, content, options) {
     }
   }
 
+  const filename = options.filename;
+  const force = !!filename && path.extname(filename) === ".mjs";
+
   const compileOptions = {
-    ast: false
+    ast: false,
+    force
   };
 
   if (reify && reify.parser) {
@@ -246,10 +250,7 @@ function readPkgInfo(dir) {
           for (let i = 0; i < filesCount; ++i) {
             // Later we'll change the value to the actual contents of the
             // file, but for now we merely register that it exists.
-            const file = cacheFiles[i];
-            if (/\.js$/.test(file)) {
-              pkgInfo.cache[file] = true;
-            }
+            pkgInfo.cache[cacheFiles[i]] = true;
           }
         }
       }

--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -27,3 +27,11 @@ if (! _compile.reified) {
     );
   }).reified = _compile;
 }
+
+const exts = require.extensions;
+const _extMjs = exts['.mjs'];
+if (! (_extMjs && _extMjs.reified)) {
+  (exts['.mjs'] = function (module, filename) {
+    return exts['.js'](module, filename);
+  }).reified = _extMjs;
+}


### PR DESCRIPTION
This PR adds `.mjs` support. It will need a unit test. If you add one I can mimic for others.