### PR TITLE
Use arrow functions for generated `module.importSync` use.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -291,7 +291,7 @@ IEVp.finalizeHoisting = function () {
       parts.push(bodyInfo.hoistedImportsString);
     }
 
-    if (parts.length > 0) {
+    if (parts.length) {
       const codeToInsert = parts.join("");
 
       if (this.magicString) {
@@ -355,21 +355,51 @@ function processRemoval(removal) {
 
 IEVp.visitImportDeclaration = function (path) {
   const decl = path.getValue();
+  const specifierCount = decl.specifiers.length;
   const parts = [];
 
-  if (decl.specifiers.length > 0) {
-    parts.push(this.generateLetDeclarations ? "let " : "var ");
-
-    const specifierCount = decl.specifiers.length;
-    const lastIndex = specifierCount - 1;
+  if (specifierCount) {
+    const identifiers = [];
+    const namespaces = [];
 
     for (let i = 0; i < specifierCount; ++i) {
       const s = decl.specifiers[i];
-      const isLast = i === lastIndex;
-      parts.push(
-        s.local.name,
-        isLast ? ";" : ","
-      );
+      const name = s.local.name;
+
+      if (s.type === "ImportNamespaceSpecifier") {
+        namespaces.push(name);
+      } else {
+        identifiers.push(name);
+      }
+    }
+
+    const identifierCount = identifiers.length;
+    if (identifierCount) {
+      const lastIndex = identifierCount - 1;
+      parts.push(this.generateLetDeclarations ? "let " : "var ");
+
+      for (let i = 0; i < identifierCount; ++i) {
+        const isLast = i === lastIndex;
+        parts.push(
+          identifiers[i],
+          isLast ? ";" : ","
+        );
+      }
+    }
+
+    const namespaceCount = namespaces.length;
+    if (namespaceCount) {
+      const lastIndex = namespaceCount - 1;
+      parts.push(this.generateLetDeclarations ? "const " : "var ");
+
+      for (let i = 0; i < namespaceCount; ++i) {
+        const isLast = i === lastIndex;
+        parts.push(
+          namespaces[i],
+          "=Object.create(null)",
+          isLast ? ";" : ","
+        );
+      }
     }
   }
 
@@ -390,7 +420,7 @@ IEVp.visitExportAllDeclaration = function (path) {
     this.pad("module.importSync(", decl.start, decl.source.start),
     this._getSourceString(decl),
     this.pad(
-      ",{'*':function(v,k){exports[k]=v;}}," +
+      ",{'*':(v,k)=>{exports[k]=v;}}," +
         this.makeUniqueKey() + ");",
       decl.source.end,
       decl.end
@@ -652,32 +682,27 @@ function toModuleImport(source, specifierMap, uniqueKey) {
     const isLast = i === lastIndex;
     const locals = specifierMap[imported];
     const valueParam = safeParam("v", locals);
-    let bind = "";
 
     parts.push(
       JSON.stringify(imported),
-      ":function(", valueParam
+      ":(", valueParam
     );
 
     if (imported === "*") {
       // There can be only one namespace import/export specifier.
       assert.strictEqual(locals.length, 1);
-      let local = locals[0];
+      const local = locals[0];
 
-      // We must be handling either an ImportNamespaceSpecifier or an
-      // ExportNamespaceSpecifier. We initialize the target object as the
-      // argument to a .bind method call on the setter function, so that
-      // we can refer to it as `this` inside the setter function.
-      bind = ".bind(" + local + "=Object.create(null))";
-      local = "this";
-
+      if (local.startsWith("exports.")) {
+        parts.unshift(`${local}=Object.create(null);`);
+      }
       // When the imported name is "*", the setter function may be called
       // multiple times, and receives an additional parameter specifying
       // the name of the property to be set.
       const nameParam = safeParam("n", [local, valueParam]);
 
       parts.push(
-        ",", nameParam, "){",
+        ",", nameParam, ")=>{",
         // The local variable should have been initialized as an empty
         // object when the variable was declared.
         local, "[", nameParam, "]=", valueParam
@@ -685,14 +710,10 @@ function toModuleImport(source, specifierMap, uniqueKey) {
 
     } else {
       // Multiple local variables become a compound assignment.
-      parts.push("){", locals.join("="), "=", valueParam);
+      parts.push(")=>{", locals.join("="), "=", valueParam);
     }
 
     parts.push("}");
-
-    if (bind.length > 0) {
-      parts.push(bind);
-    }
 
     if (! isLast) {
       parts.push(",");
@@ -731,9 +752,9 @@ function toModuleExport(specifierMap) {
 
     parts.push(
       exported,
-      ":function(){return ",
+      ":()=>",
       locals[0],
-      isLast ? "}" : "},"
+      isLast ? "" : ","
     );
   }
 


### PR DESCRIPTION
This PR tackled another item on #90
> Use arrow functions for module.import and `module.exports`, `module.import`, and `module.importSync`.
