### PR TITLE
Update tests with more ES6.

### DIFF
--- a/test/all-files.js
+++ b/test/all-files.js
@@ -10,17 +10,17 @@ import {
   statSync,
 } from "fs";
 
-export var files = Object.create(null);
+export const files = Object.create(null);
 
 function walk(dir) {
-  readdirSync(dir).forEach(function (item) {
-    var absPath = join(dir, item);
-    var stat = statSync(absPath);
+  readdirSync(dir).forEach((item) => {
+    const absPath = join(dir, item);
+    const stat = statSync(absPath);
     if (stat.isDirectory()) {
       walk(absPath);
     } else if (stat.isFile()) {
-      var relPath = relative(__dirname, absPath);
-      var relParts = relPath.split(sep);
+      const relPath = relative(__dirname, absPath);
+      const relParts = relPath.split(sep);
 
       // Ignore cache files.
       if (relParts[0] === ".cache") {

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -6,18 +6,18 @@ import { parse } from "../lib/parsers/babylon.js";
 import reifyPlugin from "babel-plugin-transform-es2015-modules-reify";
 import es2015Preset from "babel-preset-es2015";
 
-var filesToTest = Object.create(null);
+const filesToTest = Object.create(null);
 
-Object.keys(files).forEach(function (absPath) {
-  var code = files[absPath];
-  var relPath = relative(__dirname, absPath);
+Object.keys(files).forEach((absPath) => {
+  const code = files[absPath];
+  const relPath = relative(__dirname, absPath);
 
   // These files fail to transform with es2015 preset due to problems
   // unrelated to the functionality of the Reify Babel plugin.
-  if (relPath === "import-tests.js" ||
+  if (relPath === "export-some.js"  ||
       relPath === "export-tests.js" ||
-      relPath === "setter-tests.js" ||
-      relPath === "export-some.js") {
+      relPath === "import-tests.js" ||
+      relPath === "setter-tests.js") {
     return;
   }
 
@@ -29,28 +29,28 @@ Object.keys(files).forEach(function (absPath) {
   filesToTest[relPath] = code;
 });
 
-describe("babel-plugin-transform-es2015-modules-reify", function () {
+describe("babel-plugin-transform-es2015-modules-reify", () => {
   function check(code, options) {
-    var ast = parse(code);
+    const ast = parse(code);
     delete ast.tokens;
-    var result = transformFromAst(ast, code, options);
+    const result = transformFromAst(ast, code, options);
     assert.ok(/\bmodule\.(?:importSync|export)\b/.test(result.code));
     return result;
   }
 
-  Object.keys(filesToTest).forEach(function (relPath) {
-    var code = filesToTest[relPath];
-    var plugins = [[reifyPlugin, {
+  Object.keys(filesToTest).forEach((relPath) => {
+    const code = filesToTest[relPath];
+    const plugins = [[reifyPlugin, {
       generateLetDeclarations: true
     }]];
 
-    it("compiles " + relPath, function () {
-      check(code, { plugins: plugins });
+    it(`compiles ${relPath}`, () => {
+      check(code, { plugins });
     });
 
-    it("compiles " + relPath + " with es2015", function () {
+    it(`compiles ${relPath} with es2015`, () => {
       check(code, {
-        plugins: plugins,
+        plugins,
         presets: [es2015Preset]
       });
     });

--- a/test/default-expression.js
+++ b/test/default-expression.js
@@ -1,4 +1,4 @@
-var count = 0;
+let count = 0;
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.

--- a/test/default-function.js
+++ b/test/default-function.js
@@ -1,6 +1,6 @@
 import { strictEqual } from "assert";
 
-var obj = {};
+const obj = {};
 
 export default function f() {
   return obj;

--- a/test/eval.js
+++ b/test/eval.js
@@ -1,4 +1,4 @@
-var localValue = "original";
+let localValue = "original";
 export { localValue as value };
 export function run(code) {
   return eval(code);

--- a/test/export-cycle-a.js
+++ b/test/export-cycle-a.js
@@ -1,6 +1,6 @@
 function fun() {
   return true;
-};
+}
 
 import { callFun } from "./export-cycle-b";
 

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -1,9 +1,9 @@
-var assert = require("assert");
-var parserSupportsExportFromExtensions =
+const assert = require("assert");
+const parserSupportsExportFromExtensions =
   process.env.REIFY_PARSER === "babylon";
 
-describe("export declarations", function () {
-  it("should allow * exports", function () {
+describe("export declarations", () => {
+  it("should allow * exports", () => {
     import def, {
       a, b, c as d,
     } from "./export-all.js";
@@ -14,7 +14,7 @@ describe("export declarations", function () {
     assert.strictEqual(def, "default");
   });
 
-  it("should allow re-exporting import * alongside export *", function () {
+  it("should allow re-exporting import * alongside export *", () => {
     import {
       Abc, d, e, f,
     } from "./export-all-multiple.js";
@@ -27,7 +27,7 @@ describe("export declarations", function () {
     assert.strictEqual(f, "f");
   });
 
-  it("should tolerate mutual * exports", function () {
+  it("should tolerate mutual * exports", () => {
     import { a as aa, b as ab } from "./export/all-mutual-a.js";
     import { a as ba, b as bb } from "./export/all-mutual-b.js";
     assert.strictEqual(aa, "a");
@@ -36,7 +36,7 @@ describe("export declarations", function () {
     assert.strictEqual(bb, "b");
   });
 
-  it("should allow named re-exports", function test() {
+  it("should allow named re-exports", () => {
     import { a, c, v, si } from "./export-some.js";
     assert.strictEqual(a, "a");
     assert.strictEqual(c(), "c");
@@ -44,22 +44,22 @@ describe("export declarations", function () {
     assert.strictEqual(si, "cee");
   });
 
-  it("should be able to contain import declarations", function () {
+  it("should be able to contain import declarations", () => {
     import { outer } from "./nested";
     assert.deepEqual(outer(), ["a", "b", "c"]);
   });
 
-  it("should support default declarations", function () {
+  it("should support default declarations", () => {
     import g, { check } from "./default-function";
     check(g);
   });
 
-  it("should support default expressions", function () {
+  it("should support default expressions", () => {
     import count from "./default-expression";
     assert.strictEqual(count, 1);
   });
 
-  it("should be able to invoke setters later", function (done) {
+  it("should be able to invoke setters later", (done) => {
     import def, {
       val,
       exportAgain,
@@ -78,7 +78,7 @@ describe("export declarations", function () {
     assert.strictEqual(def, "default-3");
     assert.strictEqual(val, "value-2");
 
-    setTimeout(function () {
+    setTimeout(() => {
       oneLastExport();
       assert.strictEqual(def, "default-3");
       assert.strictEqual(val, "value-3");
@@ -88,9 +88,9 @@ describe("export declarations", function () {
 
   import { Script } from "vm";
 
-  var canUseClasses = false;
-  var canUseLetConst = false;
-  var canUseDestructuring = false;
+  let canUseClasses = false;
+  let canUseLetConst = false;
+  let canUseDestructuring = false;
 
   try {
     // Test if Node supports class syntax.
@@ -106,11 +106,11 @@ describe("export declarations", function () {
 
   try {
     // Test if Node supports destructuring declarations.
-    new Script("var { x, y } = {}");
+    new Script("const { x, y } = {}");
     canUseDestructuring = true;
   } catch (e) {}
 
-  it("should support all default syntax", function () {
+  it("should support all default syntax", () => {
     import number from "./export/default/number";
     assert.strictEqual(number, 42);
 
@@ -140,7 +140,7 @@ describe("export declarations", function () {
     }
   });
 
-  it("should support basic declaration syntax", function () {
+  it("should support basic declaration syntax", () => {
     import { a, b, c, d } from "./export/declarations/basic";
 
     assert.strictEqual(a, 1);
@@ -150,7 +150,7 @@ describe("export declarations", function () {
   });
 
   (canUseLetConst ? it : xit)(
-    "should support block declaration syntax", function () {
+    "should support block declaration syntax", () => {
     import { a, b, c } from "./export/declarations/block";
 
     assert.strictEqual(a, 1);
@@ -158,8 +158,8 @@ describe("export declarations", function () {
     assert.strictEqual(c, 3);
   });
 
-  it("should support all named export syntax", function () {
-    var exp = require("./export/names");
+  it("should support all named export syntax", () => {
+    const exp = require("./export/names");
 
     assert.strictEqual(exp.foo, "foo");
     assert.strictEqual(exp.bar, "bar");
@@ -173,7 +173,7 @@ describe("export declarations", function () {
     assert.strictEqual(foo, "foo");
   });
 
-  it("should tolerate one-to-many renamed exports", function () {
+  it("should tolerate one-to-many renamed exports", () => {
     import { x, y, append } from "./export/renamed";
 
     assert.strictEqual(x, y);
@@ -190,7 +190,7 @@ describe("export declarations", function () {
     assert.strictEqual(x, "abc");
   });
 
-  it("should support all export-from syntax", function () {
+  it("should support all export-from syntax", () => {
     import def, { a, b, c, ay, bee, foo } from "./export/from";
 
     assert.strictEqual(def, "a");
@@ -207,7 +207,7 @@ describe("export declarations", function () {
   });
 
   (parserSupportsExportFromExtensions ? it : xit
-  )("should support export-from extensions", function () {
+  )("should support export-from extensions", () => {
     import {
       def1, def2, def3,
       ns1, ns2, ns3,
@@ -240,17 +240,17 @@ describe("export declarations", function () {
     assert.strictEqual(d, _d);
   });
 
-  it("should support export { default } from ... syntax", function () {
+  it("should support export { default } from ... syntax", () => {
     import object from "./export/default/from";
     assert.deepEqual(object, {
       foo: 42
     });
   });
 
-  it("should support switch-case nested imports", function () {
+  it("should support switch-case nested imports", () => {
     assert.strictEqual(typeof x, "undefined");
 
-    for (var i = 0; i < 2; ++i) {
+    for (let i = 0; i < 2; ++i) {
       switch (i) {
       case 0:
         import { a as x } from "./abc";
@@ -267,7 +267,7 @@ describe("export declarations", function () {
   });
 
   (canUseDestructuring ? it : xit)(
-    "should support destructuring declarations", function () {
+    "should support destructuring declarations", () => {
     import { a, c as b, d, x, y, rest } from "./export/destructuring.js";
 
     assert.strictEqual(a, "a");
@@ -279,7 +279,7 @@ describe("export declarations", function () {
   });
 
   (canUseDestructuring ? it : xit)(
-  "should invoke destructuring setters later", function () {
+  "should invoke destructuring setters later", () => {
     import { x, y, swap } from "./export/swap-later.js";
     assert.strictEqual(x, 1);
     assert.strictEqual(y, 2);

--- a/test/export/declarations.js
+++ b/test/export/declarations.js
@@ -1,5 +1,5 @@
-export var a = 1;
-export var b = function () {};
-export var c; // lazy initialization
+export const a = 1;
+export const b = function () {};
+export let c; // lazy initialization
 export function g() {};
 c = "c";

--- a/test/export/declarations/basic.js
+++ b/test/export/declarations/basic.js
@@ -1,8 +1,8 @@
-export var a = 1;
-export var b = function () {
+export const a = 1;
+export const b = function () {
   return d;
 };
-export var c; // lazy initialization
+export let c; // lazy initialization
 export function d() {
   return b;
 };

--- a/test/export/default/anon-function.js
+++ b/test/export/default/anon-function.js
@@ -1,3 +1,3 @@
 export default function (value) {
   return value + 1;
-}
+};

--- a/test/export/default/identifier.js
+++ b/test/export/default/identifier.js
@@ -1,2 +1,2 @@
-var foo = 42;
+const foo = 42;
 export default foo;

--- a/test/export/later.js
+++ b/test/export/later.js
@@ -1,7 +1,7 @@
 import { strictEqual } from "assert";
 
 export default "default-1";
-export var val = "value-1";
+export let val = "value-1";
 
 export function exportAgain() {
   module.export("default", exports.default = "default-2");

--- a/test/export/names.js
+++ b/test/export/names.js
@@ -1,6 +1,6 @@
-var foo = "foo";
-var bar = "bar";
-var baz = "baz";
+const foo = "foo";
+const bar = "bar";
+const baz = "baz";
 
 export {foo};
 export {bar, baz};

--- a/test/export/renamed.js
+++ b/test/export/renamed.js
@@ -1,4 +1,4 @@
-var a = "a";
+let a = "a";
 
 export function append(suffix) {
   return a += suffix;

--- a/test/export/swap-later.js
+++ b/test/export/swap-later.js
@@ -1,4 +1,4 @@
 export let { x, y } = { x: 1, y: 2 };
 export function swap() {
   [x, y] = [y, x];
-}
+};

--- a/test/import-tests.js
+++ b/test/import-tests.js
@@ -1,13 +1,13 @@
-var assert = require("assert");
+const assert = require("assert");
 
-describe("import declarations", function () {
-  it("should work in nested scopes", function () {
+describe("import declarations", () => {
+  it("should work in nested scopes", () => {
     import { name, id } from "./name";
     assert.strictEqual(name, "name.js");
     assert.strictEqual(id.split("/").pop(), "name.js");
   });
 
-  it("should cope with dependency cycles", function () {
+  it("should cope with dependency cycles", () => {
     import { check as aCheck } from "./cycle-a";
     aCheck();
 
@@ -15,7 +15,7 @@ describe("import declarations", function () {
     bCheck();
   });
 
-  it("should support combinations of import styles", function () {
+  it("should support combinations of import styles", () => {
     import * as abc1 from "./abc";
     import abc2, * as abc3 from "./abc";
     import { default as abc4 } from "./abc";
@@ -33,20 +33,20 @@ describe("import declarations", function () {
     assert.deepEqual(abc1, abc5);
   });
 
-  it("should import module.exports as default, by default", function () {
+  it("should import module.exports as default, by default", () => {
     import def from "./export/common.js";
     assert.strictEqual(def, "pure CommonJS");
   });
 
-  it("should allow same symbol as different locals", function () {
+  it("should allow same symbol as different locals", () => {
     import { a as x, a as y } from "./abc";
     assert.strictEqual(x, "a");
     assert.strictEqual(y, "a");
   });
 
-  it("should support braceless-if nested imports", function () {
+  it("should support braceless-if nested imports", () => {
     assert.strictEqual(typeof x, "undefined");
-    for (var i = 0; i < 3; ++i) {
+    for (let i = 0; i < 3; ++i) {
       if (i === 0) import { a as x } from "./abc";
       else if (i === 1) import { b as x } from "./abc";
       else import { c as x } from "./abc";
@@ -55,20 +55,20 @@ describe("import declarations", function () {
     assert.strictEqual(x, "c");
   });
 
-  it("should support braceless-while nested imports", function () {
+  it("should support braceless-while nested imports", () => {
     var i = 0, x;
     while (i++ === 0) import { a as x } from "./abc";
     assert.strictEqual(x, "a");
   });
 
-  it("should support braceless-do-while nested imports", function () {
+  it("should support braceless-do-while nested imports", () => {
     var x;
     do import { b as x } from "./abc";
     while (false);
     assert.strictEqual(x, "b");
   });
 
-  it("should support braceless-for-in nested imports", function () {
+  it("should support braceless-for-in nested imports", () => {
     for (var x in { a: 123 })
       import { c as x } from "./abc";
     assert.strictEqual(x, "c");

--- a/test/lines.js
+++ b/test/lines.js
@@ -11,7 +11,7 @@ default
 function check()
 
 {
-  var error = new Error; // Line 14
-  var line = +error.stack.split("\n")[1].split(":")[1];
+  const error = new Error; // Line 14
+  const line = +error.stack.split("\n")[1].split(":")[1];
   strictEqual(line, 14);
 }

--- a/test/misc-tests.js
+++ b/test/misc-tests.js
@@ -1,7 +1,7 @@
-var assert = require("assert");
+const assert = require("assert");
 
-describe("spec compliance", function () {
-  it("should establish live binding of values", function () {
+describe("spec compliance", () => {
+  it("should establish live binding of values", () => {
     import { value, reset, add } from "./live";
     reset();
     assert.equal(value, 0);
@@ -9,20 +9,20 @@ describe("spec compliance", function () {
     assert.equal(value, 2);
   });
 
-  it("should execute modules in the correct order", function () {
+  it("should execute modules in the correct order", () => {
     import { getLog } from "./order-tracker";
     import "./order-c";
     assert.deepEqual(getLog(), ["a", "b", "c"]);
   });
 
-  it("should bind exports before the module executes", function () {
+  it("should bind exports before the module executes", () => {
     import value from "./export-cycle-a";
     assert.equal(value, true);
   });
 });
 
-describe("built-in modules", function () {
-  it("should fire setters if already loaded", function () {
+describe("built-in modules", () => {
+  it("should fire setters if already loaded", () => {
     // The "module" module is required in ../lib/node.js before we begin
     // compiling anything.
     import { Module as M } from "module";

--- a/test/name.js
+++ b/test/name.js
@@ -1,6 +1,6 @@
-var path = require("path");
+const path = require("path");
 
-export var id = module.id,
+export const id = module.id,
   name = path.basename(__filename);
 
 export function foo() {

--- a/test/order-tracker.js
+++ b/test/order-tracker.js
@@ -1,4 +1,4 @@
-var data = [];
+const data = [];
 export function log(x) {
   data.push(x);
 };

--- a/test/output/declarations-basic/actual.js
+++ b/test/output/declarations-basic/actual.js
@@ -1,8 +1,8 @@
-export var a = 1;
-export var b = function () {
+export const a = 1;
+export const b = function () {
   return d;
 };
-export var c; // lazy initialization
+export let c; // lazy initialization
 export function d() {
   return b;
 };

--- a/test/output/declarations-basic/expected.js
+++ b/test/output/declarations-basic/expected.js
@@ -1,8 +1,8 @@
-"use strict";module.export({a:()=>a,b:()=>b,c:()=>c,d:()=>d});var a = 1;
-var b = function () {
+"use strict";module.export({a:()=>a,b:()=>b,c:()=>c,d:()=>d});const a = 1;
+const b = function () {
   return d;
 };
-var c; // lazy initialization
+let c; // lazy initialization
 function d() {
   return b;
 };

--- a/test/output/default-expression/actual.js
+++ b/test/output/default-expression/actual.js
@@ -1,4 +1,4 @@
-var count = 0;
+let count = 0;
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.

--- a/test/output/default-expression/expected.js
+++ b/test/output/default-expression/expected.js
@@ -1,4 +1,4 @@
-"use strict";var count = 0;
+"use strict";let count = 0;
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.

--- a/test/output/default-function/actual.js
+++ b/test/output/default-function/actual.js
@@ -1,6 +1,6 @@
 import { strictEqual } from "assert";
 
-var obj = {};
+const obj = {};
 
 export default function f() {
   return obj;

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,6 +1,6 @@
 "use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v}},0);
 
-var obj = {};
+const obj = {};
 
 function f() {
   return obj;

--- a/test/output/eval/actual.js
+++ b/test/output/eval/actual.js
@@ -1,4 +1,4 @@
-var localValue = "original";
+let localValue = "original";
 export { localValue as value };
 export function run(code) {
   return eval(code);

--- a/test/output/eval/expected.js
+++ b/test/output/eval/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({value:()=>localValue,run:()=>run});var localValue = "original";
+"use strict";module.export({value:()=>localValue,run:()=>run});let localValue = "original";
 
 function run(code) {
   return module.runModuleSetters(eval(code));

--- a/test/output/lines/actual.js
+++ b/test/output/lines/actual.js
@@ -11,7 +11,7 @@ default
 function check()
 
 {
-  var error = new Error; // Line 14
-  var line = +error.stack.split("\n")[1].split(":")[1];
+  const error = new Error; // Line 14
+  const line = +error.stack.split("\n")[1].split(":")[1];
   strictEqual(line, 14);
 }

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -11,7 +11,7 @@
 function check()
 
 {
-  var error = new Error; // Line 14
-  var line = +error.stack.split("\n")[1].split(":")[1];
+  const error = new Error; // Line 14
+  const line = +error.stack.split("\n")[1].split(":")[1];
   strictEqual(line, 14);
 }

--- a/test/output/name/actual.js
+++ b/test/output/name/actual.js
@@ -1,6 +1,6 @@
-var path = require("path");
+const path = require("path");
 
-export var id = module.id,
+export const id = module.id,
   name = path.basename(__filename);
 
 export function foo() {

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,6 +1,6 @@
-"use strict";module.export({id:()=>id,name:()=>name,foo:()=>foo});var path = require("path");
+"use strict";module.export({id:()=>id,name:()=>name,foo:()=>foo});const path = require("path");
 
-var id = module.id,
+const id = module.id,
   name = path.basename(__filename);
 
 function foo() {

--- a/test/repl-tests.js
+++ b/test/repl-tests.js
@@ -1,11 +1,11 @@
-var assert = require("assert");
+const assert = require("assert");
 
-describe("Node REPL", function () {
+describe("Node REPL", () => {
   import { createContext } from "vm";
   import "../repl";
 
-  it("should work with global context", function (done) {
-    var repl = require("repl").start({
+  it("should work with global context", (done) => {
+    const repl = require("repl").start({
       useGlobal: true
     });
 
@@ -13,9 +13,9 @@ describe("Node REPL", function () {
 
     repl.eval(
       'import { strictEqual as assertStrictEqual } from "assert"',
-      null, // context
-      "repl", // filename
-      function (err, result) {
+      null, // Context
+      "repl", // Filename
+      (err, result) => {
         // Use the globally-defined assertStrictEqual to test itself!
         assertStrictEqual(typeof assertStrictEqual, "function");
         done();
@@ -23,20 +23,20 @@ describe("Node REPL", function () {
     );
   });
 
-  it("should work with non-global context", function (done) {
-    var repl = require("repl").start({
+  it("should work with non-global context", (done) => {
+    const repl = require("repl").start({
       useGlobal: false
     });
 
-    var context = createContext({
+    const context = createContext({
       module: module
     });
 
     repl.eval(
       'import { strictEqual } from "assert"',
       context,
-      "repl", // filename
-      function (err, result) {
+      "repl", // Filename
+      (err, result) => {
         // Use context.strictEqual to test itself!
         context.strictEqual(typeof context.strictEqual, "function");
         done();

--- a/test/run.js
+++ b/test/run.js
@@ -1,5 +1,5 @@
 describe("Parsing with " + JSON.stringify(
   process.env.REIFY_PARSER || "acorn"
-), function () {
+), () => {
   require("./tests.js");
 });

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -1,17 +1,17 @@
-var assert = require("assert");
+const assert = require("assert");
 
-describe("module.runModuleSetters", function () {
-  it("should be called after eval(...)", function () {
+describe("module.runModuleSetters", () => {
+  it("should be called after eval(...)", () => {
     import { value, run } from "./eval";
     assert.strictEqual(value, "original");
-    var result = run('localValue = "modified"');
+    const result = run('localValue = "modified"');
     assert.strictEqual(value, result);
     assert.strictEqual(value, "modified");
   });
 });
 
-describe("parent setters", function () {
-  it("should be run when children update exports", function () {
+describe("parent setters", () => {
+  it("should be run when children update exports", () => {
     import { c } from "./setters/parent";
     import { increment } from "./setters/grandchild";
     assert.strictEqual(c, 0);
@@ -19,14 +19,14 @@ describe("parent setters", function () {
     assert.strictEqual(c, 1);
   });
 
-  it("should not be called if replaced", function () {
+  it("should not be called if replaced", () => {
     import { value, reset, add } from "./live.js";
 
-    var firstCallCount = 0;
-    var secondCallCount = 0;
+    let firstCallCount = 0;
+    let secondCallCount = 0;
 
     module.importSync("./live.js", {
-      value: function (v) {
+      value: (v) => {
         ++firstCallCount;
         value = "first:" + v;
       }
@@ -40,7 +40,7 @@ describe("parent setters", function () {
     assert.strictEqual(secondCallCount, 0);
 
     module.importSync("./live.js", {
-      value: function (v) {
+      value: (v) => {
         ++secondCallCount;
         value = "second:" + v;
       }

--- a/test/setters/grandchild.js
+++ b/test/setters/grandchild.js
@@ -1,4 +1,4 @@
-export var c = 0;
+export let c = 0;
 export function increment() {
   ++c;
   module.export();

--- a/test/transform-tests.js
+++ b/test/transform-tests.js
@@ -1,12 +1,10 @@
-"use strict";
-
 import assert from "assert";
 import { relative } from "path";
 import { compile, transform } from "../lib/compiler.js";
 import { prettyPrint } from "recast";
 import { files } from "./all-files.js";
 
-describe("compiler.transform", function () {
+describe("compiler.transform", () => {
   function check(options) {
     Object.keys(files).forEach(function (absPath) {
       if (typeof options.filter === "function" &&
@@ -27,18 +25,18 @@ describe("compiler.transform", function () {
     });
   }
 
-  it("gives the same results as compile with babylon", function () {
+  it("gives the same results as compile with babylon", () => {
     check({
       ast: true,
       parse: require("../lib/parsers/babylon.js").parse
     });
   }).timeout(5000);
 
-  it("gives the same results as compile with acorn", function () {
+  it("gives the same results as compile with acorn", () => {
     check({
       ast: true,
       parse: require("../lib/parsers/acorn.js").parse,
-      filter: function (relPath) {
+      filter: (relPath) => {
         // Acorn can't parse this file, so we skip it.
         return relPath !== "export/from-extensions.js";
       }


### PR DESCRIPTION
This PR adds more ES6.

It'll be interesting to see how more ES6 is handled for `let` and `const` in Node 4 without the implicit `"use strict"` being added yet.