### PR TITLE
Preserve crlf line endings of code.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -6,6 +6,7 @@ const MagicString = require("./magic-string.js");
 const utils = require("./utils.js");
 const Visitor = require("./visitor.js");
 
+const carrageReturnCode = "\r".charCodeAt(0);
 const exportDefaultPrefix = "module.export('default',exports.default=(";
 const exportDefaultSuffix = "));";
 const hasOwn = Object.prototype.hasOwnProperty;
@@ -276,11 +277,15 @@ module.exports = class ImportExportVisitor extends Visitor {
     if (this.code) {
       const oldLines = this.code.slice(oldStart, oldEnd).split("\n");
       const newLines = newCode.split("\n");
+      const line = oldLines[0];
+      const endCode = line.charCodeAt(line.length - 1);
+      const lineEnd = endCode === carrageReturnCode ? "\r\n" : "\n";
       let diff = oldLines.length - newLines.length;
+
       while (diff --> 0) {
         newLines.push("");
       }
-      newCode = newLines.join("\n");
+      newCode = newLines.join(lineEnd);
     }
     return newCode;
   }

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -186,4 +186,20 @@ describe("compiler", function () {
     var withShebang = compile(code).code;
     assert.strictEqual(withShebang.indexOf('var foo'), 0)
   });
+
+  it("should preserve crlf newlines", () => {
+    import { compile } from "../lib/compiler.js";
+
+    const code = [
+      "import {",
+      "  strictEqual,",
+      "  // blank line",
+      "  deepEqual",
+      "}",
+      'from "assert";'
+    ].join("\r\n");
+
+    const result = compile(code).code;
+    assert.ok(result.endsWith("\r\n".repeat(5)));
+  });
 });


### PR DESCRIPTION
I noticed that padding didn't account for crlf. This patch addresses that for those folks on Windows boxes.