### PR TITLE
Avoid pulling package.json into the bundle.

### DIFF
--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -12,8 +12,9 @@ const pkgInfoCache = Object.create(null);
 
 // Take only the major and minor components of the reify version, so that
 // we don't invalidate the cache every time a patch version is released.
-const reifyVersion = require("../package.json")
-  .version.split(".", 2).join(".");
+const reifyVersion =
+  (process.env.REIFY_VERSION || dynRequire("../package.json").version)
+    .split(".", 2).join(".");
 
 const DEFAULT_CACHE_DIR = ".reify-cache";
 


### PR DESCRIPTION
This PR avoids pulling package.json into the bundle. I was surprise to see that it actually pulls it in as a big complete json object.

#### webpack.config.js
```js
'use strict'

// "uglify-js": "git://github.com/mishoo/UglifyJS2.git#harmony",
// "uglifyjs-webpack-plugin": "^0.3.0"
const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
const webpack = require('webpack')

module.exports = {
  'target': 'node',
  'plugins': [
    new webpack.DefinePlugin({
      'process.env.REIFY_VERSION': JSON.stringify(require('./package.json').version),
      'process.env.REIFY_PARSER': '"top-level"'
    }),
    new UglifyJSPlugin({
      'compress': {
        'collapse_vars': true,
        'negate_iife': false,
        'pure_getters': true,
        'unsafe': true,
        'warnings': false
      },
      'output': {
        'ascii_only': true,
        'comments': /@license/,
        'max_line_len': 500
      }
    })
  ]
}
```