### PR TITLE
Fix a perf regression in Node v4.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -410,7 +410,7 @@ module.exports = class ImportExportVisitor extends Visitor {
       this.pad("module.importSync(", decl.start, decl.source.start),
       this._getSourceString(decl),
       this.pad(
-        ",{'*':(v,k)=>{exports[k]=v;}}," +
+        ",{'*':function(v,k){exports[k]=v;}}," +
           this.makeUniqueKey() + ");",
         decl.source.end,
         decl.end
@@ -676,9 +676,11 @@ function toModuleImport(source, specifierMap, uniqueKey) {
     const locals = specifierMap[imported];
     const valueParam = safeParam("v", locals);
 
+    // Generate plain functions, instead of arrow functions, to avoid a perf
+    // hit in Node 4.
     parts.push(
       JSON.stringify(imported),
-      ":(", valueParam
+      ":function(", valueParam
     );
 
     if (imported === "*") {
@@ -695,7 +697,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
       const nameParam = safeParam("n", [local, valueParam]);
 
       parts.push(
-        ",", nameParam, ")=>{",
+        ",", nameParam, "){",
         // The local variable should have been initialized as an empty
         // object when the variable was declared.
         local, "[", nameParam, "]=", valueParam
@@ -703,7 +705,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
 
     } else {
       // Multiple local variables become a compound assignment.
-      parts.push(")=>{", locals.join("="), "=", valueParam);
+      parts.push("){", locals.join("="), "=", valueParam);
     }
 
     parts.push("}");

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{"strictEqual":(v)=>{strictEqual=v}},0);
+module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v}},0);
 
 var obj = {};
 

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,1 +1,1 @@
-module.export({Abc:()=>n});module.importSync("./def",{'*':(v,k)=>{exports[k]=v;}},1);var n=Object.create(null);module.importSync("./abc",{"*":(v,_n)=>{n[_n]=v}},0);
+module.export({Abc:()=>n});module.importSync("./def",{'*':function(v,k){exports[k]=v;}},1);var n=Object.create(null);module.importSync("./abc",{"*":function(v,_n){n[_n]=v}},0);

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,2 @@
-module.importSync("./abc",{'*':(v,k)=>{exports[k]=v;}},0);
+module.importSync("./abc",{'*':function(v,k){exports[k]=v;}},0);
 module.export('default',exports.default=("default"));

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{"a":(v)=>{exports.a=v},"b":(v)=>{exports.v=v}},0);var cee;module.importSync("./abc.js",{"c":(v)=>{cee=v}},1);
+module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{"a":function(v){exports.a=v},"b":function(v){exports.v=v}},0);var cee;module.importSync("./abc.js",{"c":function(v){cee=v}},1);
 
 
 module.runModuleSetters(cee += "ee");

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{"strictEqual":(v)=>{strictEqual=v},"deepEqual":(v)=>{deepEqual=v}},0);
+module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v},"deepEqual":function(v){deepEqual=v}},0);
 
 
 

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{"a":(v)=>{ay=v}},0);var bee;module.importSync("./abc",{"b":(v)=>{bee=v}},1);var see;module.importSync("./abc",{"c":(v)=>{see=v}},2);
+module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{"a":function(v){ay=v}},0);var bee;module.importSync("./abc",{"b":function(v){bee=v}},1);var see;module.importSync("./abc",{"c":function(v){see=v}},2);
 
 
 


### PR DESCRIPTION
I noticed that the transpile time had spiked in Node v4 by 500+ms for the benchmark.
After investigation it looks like generated arrow function use in the runtime caused the slow down.
I'll check back in after we add `"use strict"` to see if anything changes.