### PR TITLE
Add "use strict" to any modules containing import or export declarations

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -21,13 +21,17 @@ exports.compile = function (code, options) {
 
   const result = { ast: null, code };
 
-  if (! getOption(options, "force") &&  ! importExportRegExp.test(code)) {
+  if (! getOption(options, "force") &&
+      ! importExportRegExp.test(code)) {
+    // Let the caller know the result is no different from the input.
+    options.identical = true;
 
     if (getOption(options, "ast")) {
       // To take full advantage of identity checking, you should probably
       // pass the { ast: false } option to the compile function.
       result.ast = parse(code);
     }
+
     return result;
   }
 
@@ -38,13 +42,19 @@ exports.compile = function (code, options) {
 
   const magicString = importExportVisitor.magicString;
 
-  assignmentVisitor.visit(rootPath, {
-    exportedLocalNames: importExportVisitor.exportedLocalNames,
-    magicString: magicString,
-    modifyAST: importExportVisitor.modifyAST
-  });
+  if (importExportVisitor.madeChanges) {
+    assignmentVisitor.visit(rootPath, {
+      exportedLocalNames: importExportVisitor.exportedLocalNames,
+      magicString: magicString,
+      modifyAST: importExportVisitor.modifyAST
+    });
 
-  importExportVisitor.finalizeHoisting();
+    importExportVisitor.finalizeHoisting();
+
+  } else {
+    // Let the caller know the result is no different from the input.
+    options.identical = true;
+  }
 
   if (importExportVisitor.modifyAST) {
     // If the importExportVisitor modified the AST because options.ast was
@@ -70,12 +80,18 @@ exports.transform = function (ast, options) {
     importExportOptions
   );
 
-  assignmentVisitor.visit(rootPath, {
-    exportedLocalNames: importExportVisitor.exportedLocalNames,
-    modifyAST: true
-  });
+  if (importExportVisitor.madeChanges) {
+    assignmentVisitor.visit(rootPath, {
+      exportedLocalNames: importExportVisitor.exportedLocalNames,
+      modifyAST: true
+    });
 
-  importExportVisitor.finalizeHoisting();
+    importExportVisitor.finalizeHoisting();
+
+  } else {
+    // Let the caller know the result is no different from the input.
+    options.identical = true;
+  }
 
   return ast;
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -19,12 +19,16 @@ exports.compile = function (code, options) {
   const parse = getOption(options, "parse");
   code = code.replace(shebangRegExp, "");
 
-  const result = { ast: null, code };
+  const result = {
+    code,
+    ast: null,
+    identical: false
+  };
 
   if (! getOption(options, "force") &&
       ! importExportRegExp.test(code)) {
     // Let the caller know the result is no different from the input.
-    options.identical = true;
+    result.identical = true;
 
     if (getOption(options, "ast")) {
       // To take full advantage of identity checking, you should probably
@@ -53,7 +57,7 @@ exports.compile = function (code, options) {
 
   } else {
     // Let the caller know the result is no different from the input.
-    options.identical = true;
+    result.identical = true;
   }
 
   if (importExportVisitor.modifyAST) {
@@ -80,6 +84,8 @@ exports.transform = function (ast, options) {
     importExportOptions
   );
 
+  const result = { ast, identical: false };
+
   if (importExportVisitor.madeChanges) {
     assignmentVisitor.visit(rootPath, {
       exportedLocalNames: importExportVisitor.exportedLocalNames,
@@ -90,8 +96,8 @@ exports.transform = function (ast, options) {
 
   } else {
     // Let the caller know the result is no different from the input.
-    options.identical = true;
+    result.identical = true;
   }
 
-  return ast;
+  return result;
 };

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -39,6 +39,7 @@ module.exports = class ImportExportVisitor extends Visitor {
     const node = path.getNode();
     const parent = path.getParentNode();
 
+    let needToAddUseStrictDirective = false;
     let insertCharIndex = node.start;
     let bodyName = "body";
     let body;
@@ -47,6 +48,11 @@ module.exports = class ImportExportVisitor extends Visitor {
     case "Program":
       body = parent.body;
       insertCharIndex = parent.start;
+
+      // If parent is a Program, we may need to add a "use strict"
+      // directive to enable const/let in Node 4.
+      needToAddUseStrictDirective = this.enforceStrictMode;
+
       break;
 
     case "BlockStatement":
@@ -103,6 +109,11 @@ module.exports = class ImportExportVisitor extends Visitor {
             typeof expr.value === "string")) {
           insertCharIndex = stmt.end;
           insertNodeIndex = i + 1;
+          if (expr.value === "use strict") {
+            // If there's already a "use strict" directive, then we don't
+            // need to add another one.
+            needToAddUseStrictDirective = false;
+          }
           continue;
         }
       }
@@ -114,9 +125,14 @@ module.exports = class ImportExportVisitor extends Visitor {
     const directives = parent.directives;
     if (directives) {
       const directiveCount = directives.length;
-
       for (let i = 0; i < directiveCount; ++i) {
-        insertCharIndex = Math.max(directives[i].end, insertCharIndex);
+        const d = directives[i];
+        insertCharIndex = Math.max(d.end, insertCharIndex);
+        if (d.value.value === "use strict") {
+          // If there's already a "use strict" directive, then we don't
+          // need to add another one.
+          needToAddUseStrictDirective = false;
+        }
       }
     }
 
@@ -140,6 +156,10 @@ module.exports = class ImportExportVisitor extends Visitor {
       this.bodyInfos.push(bodyInfo);
     }
 
+    bodyInfo.needToAddUseStrictDirective =
+      needToAddUseStrictDirective ||
+      bodyInfo.needToAddUseStrictDirective;
+
     return bodyInfo;
   }
 
@@ -147,6 +167,7 @@ module.exports = class ImportExportVisitor extends Visitor {
     this.preserveChild(importDeclPath, childName);
     const bodyInfo = this.getBlockBodyInfo(importDeclPath);
     bodyInfo.hoistedImportsString += hoistedCode;
+    this.madeChanges = true;
     return this;
   }
 
@@ -176,6 +197,8 @@ module.exports = class ImportExportVisitor extends Visitor {
       bodyInfo.hoistedExportsString += mapOrString;
     }
 
+    this.madeChanges = true;
+
     return this;
   }
 
@@ -185,6 +208,13 @@ module.exports = class ImportExportVisitor extends Visitor {
     for (let i = 0; i < infoCount; ++i) {
       const bodyInfo = this.bodyInfos[i];
       const parts = [];
+
+      // We don't need to add a "use strict" directive unless the compiler
+      // made any changes.
+      if (this.madeChanges &&
+          bodyInfo.needToAddUseStrictDirective) {
+        parts.push('"use strict";');
+      }
 
       const namedExports = toModuleExport(bodyInfo.hoistedExportsMap);
       if (namedExports) {
@@ -226,6 +256,7 @@ module.exports = class ImportExportVisitor extends Visitor {
       delete bodyInfo.hoistedImportsString;
       delete bodyInfo.insertCharIndex;
       delete bodyInfo.insertNodeIndex;
+      delete bodyInfo.needToAddUseStrictDirective;
     }
 
     // Just in case we call finalizeHoisting again, don't hoist anything.
@@ -347,9 +378,19 @@ module.exports = class ImportExportVisitor extends Visitor {
       !! getOption(options, "generateLetDeclarations");
     this.modifyAST = !! getOption(options, "ast");
     this.parse = getOption(options, "parse");
+    this.enforceStrictMode = getOption(options, "enforceStrictMode");
     this.nextKey = 0;
+    this.madeChanges = false;
 
     return this;
+  }
+
+  visitProgram(path) {
+    this.visitChildren(path);
+    path.call(
+      firstStmtPath => this.getBlockBodyInfo(firstStmtPath),
+      "body", 0
+    );
   }
 
   visitImportDeclaration(path) {
@@ -468,6 +509,8 @@ module.exports = class ImportExportVisitor extends Visitor {
 
         path.replace(this._buildExportDefaultStatement(dd));
       }
+
+      this.madeChanges = true;
     }
   }
 

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -147,6 +147,7 @@ module.exports = class ImportExportVisitor extends Visitor {
       bodyInfo = bibn[bodyName] = Object.create(null);
 
       bodyInfo.body = body;
+      bodyInfo.parent = parent;
       bodyInfo.insertCharIndex = insertCharIndex;
       bodyInfo.insertNodeIndex = insertNodeIndex;
       bodyInfo.hoistedExportsMap = Object.create(null);
@@ -241,16 +242,31 @@ module.exports = class ImportExportVisitor extends Visitor {
 
         if (this.modifyAST) {
           let ast = this.parse(codeToInsert);
+
           if (ast.type === "File") ast = ast.program;
           assert.strictEqual(ast.type, "Program");
+
           const spliceArgs = ast.body;
           spliceArgs.unshift(bodyInfo.insertNodeIndex, 0);
+
           const body = bodyInfo.body;
           body.splice.apply(body, spliceArgs);
+
+          const parsedDirectives = ast.directives;
+          const parentDirectives = bodyInfo.parent.directives;
+
+          if (parsedDirectives &&
+              parentDirectives) {
+            parentDirectives.push.apply(
+              parentDirectives,
+              parsedDirectives
+            );
+          }
         }
       }
 
       delete bodyInfo.body;
+      delete bodyInfo.parent;
       delete bodyInfo.hoistedExportsMap;
       delete bodyInfo.hoistedExportsString;
       delete bodyInfo.hoistedImportsString;

--- a/lib/options.js
+++ b/lib/options.js
@@ -6,6 +6,9 @@ const defaultCompileOptions = {
   ast: false,
   force: false,
   generateLetDeclarations: false,
+  // If not false, "use strict" will be added to any modules with at least
+  // one import or export declaration.
+  enforceStrictMode: true,
   get parse () {
     return require("./parsers/default.js").parse;
   }

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -92,9 +92,10 @@ function compileWithCache(pkgInfo, content, options) {
     compileOptions.parse = dynRequire(reify.parser).parse;
   };
 
-  content = compile(content, compileOptions).code;
+  const result = compile(content, compileOptions);
+  content = result.code;
 
-  if (compileOptions.identical) {
+  if (result.identical) {
     // Don't bother caching result if compiler made no changes.
     return content;
   }

--- a/test/output/anon-class/expected.js
+++ b/test/output/anon-class/expected.js
@@ -1,4 +1,4 @@
-module.export('default',exports.default=(class {
+"use strict";module.export('default',exports.default=(class {
   constructor(value) {
     this.value = value;
   }

--- a/test/output/declarations-basic/expected.js
+++ b/test/output/declarations-basic/expected.js
@@ -1,4 +1,4 @@
-module.export({a:()=>a,b:()=>b,c:()=>c,d:()=>d});var a = 1;
+"use strict";module.export({a:()=>a,b:()=>b,c:()=>c,d:()=>d});var a = 1;
 var b = function () {
   return d;
 };

--- a/test/output/default-expression/expected.js
+++ b/test/output/default-expression/expected.js
@@ -1,4 +1,4 @@
-var count = 0;
+"use strict";var count = 0;
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v}},0);
+"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v}},0);
 
 var obj = {};
 

--- a/test/output/eval/expected.js
+++ b/test/output/eval/expected.js
@@ -1,4 +1,4 @@
-module.export({value:()=>localValue,run:()=>run});var localValue = "original";
+"use strict";module.export({value:()=>localValue,run:()=>run});var localValue = "original";
 
 function run(code) {
   return module.runModuleSetters(eval(code));

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,1 +1,1 @@
-module.export({Abc:()=>n});module.importSync("./def",{'*':function(v,k){exports[k]=v;}},1);var n=Object.create(null);module.importSync("./abc",{"*":function(v,_n){n[_n]=v}},0);
+"use strict";module.export({Abc:()=>n});module.importSync("./def",{'*':function(v,k){exports[k]=v;}},1);var n=Object.create(null);module.importSync("./abc",{"*":function(v,_n){n[_n]=v}},0);

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,2 @@
-module.importSync("./abc",{'*':function(v,k){exports[k]=v;}},0);
+"use strict";module.importSync("./abc",{'*':function(v,k){exports[k]=v;}},0);
 module.export('default',exports.default=("default"));

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{"a":function(v){exports.a=v},"b":function(v){exports.v=v}},0);var cee;module.importSync("./abc.js",{"c":function(v){cee=v}},1);
+"use strict";module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{"a":function(v){exports.a=v},"b":function(v){exports.v=v}},0);var cee;module.importSync("./abc.js",{"c":function(v){cee=v}},1);
 
 
 module.runModuleSetters(cee += "ee");

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v},"deepEqual":function(v){deepEqual=v}},0);
+"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v},"deepEqual":function(v){deepEqual=v}},0);
 
 
 

--- a/test/output/live/expected.js
+++ b/test/output/live/expected.js
@@ -1,4 +1,4 @@
-module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
+"use strict";module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
 
 function reset() {
   return module.runModuleSetters(value = 0);

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,4 +1,4 @@
-module.export({id:()=>id,name:()=>name,foo:()=>foo});var path = require("path");
+"use strict";module.export({id:()=>id,name:()=>name,foo:()=>foo});var path = require("path");
 
 var id = module.id,
   name = path.basename(__filename);

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{"a":function(v){ay=v}},0);var bee;module.importSync("./abc",{"b":function(v){bee=v}},1);var see;module.importSync("./abc",{"c":function(v){see=v}},2);
+"use strict";module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{"a":function(v){ay=v}},0);var bee;module.importSync("./abc",{"b":function(v){bee=v}},1);var see;module.importSync("./abc",{"c":function(v){see=v}},2);
 
 
 

--- a/test/output/only-nested/actual.js
+++ b/test/output/only-nested/actual.js
@@ -1,0 +1,3 @@
+function f() {
+  import { a, b as c } from "./module";
+}

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,0 +1,3 @@
+"use strict";function f() {var a,c;module.importSync("./module",{"a":function(v){a=v},"b":function(v){c=v}},0);
+
+}

--- a/test/transform-tests.js
+++ b/test/transform-tests.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import assert from "assert";
 import { relative } from "path";
 import { compile, transform } from "../lib/compiler.js";
@@ -12,10 +14,14 @@ describe("compiler.transform", function () {
         return;
       }
 
-      var code = files[absPath];
+      const code = files[absPath];
+      const ast = options.parse(code);
+
+      transform(ast, options);
+
       assert.strictEqual(
         prettyPrint(compile(code, options).ast).code,
-        prettyPrint(transform(options.parse(code), options)).code,
+        prettyPrint(ast).code,
         "Transform mismatch for " + absPath
       );
     });


### PR DESCRIPTION
Addresses an item from #90.

Should help with Node 4 tests: https://github.com/benjamn/reify/pull/112#issuecomment-292797463