### PR TITLE
Simplify method return values since we’re the only consumer.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -169,7 +169,6 @@ module.exports = class ImportExportVisitor extends Visitor {
     const bodyInfo = this.getBlockBodyInfo(importDeclPath);
     bodyInfo.hoistedImportsString += hoistedCode;
     this.madeChanges = true;
-    return this;
   }
 
   hoistExports(exportDeclPath, mapOrString, childName) {
@@ -199,8 +198,6 @@ module.exports = class ImportExportVisitor extends Visitor {
     }
 
     this.madeChanges = true;
-
-    return this;
   }
 
   finalizeHoisting() {
@@ -289,7 +286,7 @@ module.exports = class ImportExportVisitor extends Visitor {
 
   overwrite(oldStart, oldEnd, newCode, trailing) {
     if (! this.code) {
-      return this;
+      return;
     }
 
     assert.strictEqual(typeof oldStart, "number");
@@ -312,8 +309,6 @@ module.exports = class ImportExportVisitor extends Visitor {
     } else {
       this.magicString.overwrite(oldStart, oldEnd, padded);
     }
-
-    return this;
   }
 
   pad(newCode, oldStart, oldEnd) {
@@ -348,7 +343,8 @@ module.exports = class ImportExportVisitor extends Visitor {
           value.start,
           child.start,
           ""
-        ).overwrite(
+        );
+        this.overwrite(
           child.end,
           value.end,
           ""
@@ -375,8 +371,6 @@ module.exports = class ImportExportVisitor extends Visitor {
         });
       }
     }
-
-    return this;
   }
 
   reset(rootPath, codeOrNull, options) {
@@ -397,8 +391,6 @@ module.exports = class ImportExportVisitor extends Visitor {
     this.enforceStrictMode = getOption(options, "enforceStrictMode");
     this.nextKey = 0;
     this.madeChanges = false;
-
-    return this;
   }
 
   visitProgram(path) {
@@ -466,8 +458,6 @@ module.exports = class ImportExportVisitor extends Visitor {
     ));
 
     this.hoistImports(path, parts.join(""));
-
-    return false;
   }
 
   visitExportAllDeclaration(path) {
@@ -484,8 +474,6 @@ module.exports = class ImportExportVisitor extends Visitor {
     ];
 
     this.hoistExports(path, parts.join(""));
-
-    return false;
   }
 
   visitExportDefaultDeclaration(path) {
@@ -597,8 +585,6 @@ module.exports = class ImportExportVisitor extends Visitor {
         this.addExportedLocalNames(specifierMap);
       }
     }
-
-    return false;
   }
 
   _buildExportDefaultStatement(declaration) {


### PR DESCRIPTION
This PR simplifies the return values of methods since we're the only consumer. In almost all cases the return value isn't used.