### PR TITLE
Avoid quotes on generated keys when possible.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -7,7 +7,7 @@ const utils = require("./utils.js");
 const Visitor = require("./visitor.js");
 
 const carriageReturnCode = "\r".charCodeAt(0);
-const exportDefaultPrefix = "module.export('default',exports.default=(";
+const exportDefaultPrefix = 'module.export("default",exports.default=(';
 const exportDefaultSuffix = "));";
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -476,7 +476,7 @@ module.exports = class ImportExportVisitor extends Visitor {
       this.pad("module.importSync(", decl.start, decl.source.start),
       this._getSourceString(decl),
       this.pad(
-        ",{'*':function(v,k){exports[k]=v}}," +
+        ',{"*":function(v,k){exports[k]=v}},' +
           this.makeUniqueKey() + ");",
         decl.source.end,
         decl.end
@@ -717,6 +717,13 @@ function processRemoval(removal) {
   }
 }
 
+function safeKey(key) {
+  if (/^[_$a-zA-Z]\w*$/.test(key)) {
+    return key;
+  }
+  return JSON.stringify(key);
+}
+
 function safeParam(param, locals) {
   if (locals.indexOf(param) < 0) {
     return param;
@@ -747,7 +754,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
     // Generate plain functions, instead of arrow functions, to avoid a perf
     // hit in Node 4.
     parts.push(
-      JSON.stringify(imported),
+      safeKey(imported),
       ":function(", valueParam
     );
 

--- a/test/output/anon-class/expected.js
+++ b/test/output/anon-class/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export('default',exports.default=(class {
+"use strict";module.export("default",exports.default=(class {
   constructor(value) {
     this.value = value;
   }

--- a/test/output/default-expression/expected.js
+++ b/test/output/default-expression/expected.js
@@ -2,4 +2,4 @@
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.
-module.export('default',exports.default=(count++, count));
+module.export("default",exports.default=(count++, count));

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v}},0);
+"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{strictEqual:function(v){strictEqual=v}},0);
 
 const obj = {};
 

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,1 +1,1 @@
-"use strict";module.export({Abc:()=>n});module.importSync("./def",{'*':function(v,k){exports[k]=v}},1);var n=Object.create(null);module.importSync("./abc",{"*":function(v,_n){n[_n]=v}},0);
+"use strict";module.export({Abc:()=>n});module.importSync("./def",{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.importSync("./abc",{"*":function(v,_n){n[_n]=v}},0);

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,2 @@
-"use strict";module.importSync("./abc",{'*':function(v,k){exports[k]=v}},0);
-module.export('default',exports.default=("default"));
+"use strict";module.importSync("./abc",{"*":function(v,k){exports[k]=v}},0);
+module.export("default",exports.default=("default"));

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{"a":function(v){exports.a=v},"b":function(v){exports.v=v}},0);var cee;module.importSync("./abc.js",{"c":function(v){cee=v}},1);
+"use strict";module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.importSync("./abc.js",{c:function(v){cee=v}},1);
 
 
 module.runModuleSetters(cee += "ee");

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{"strictEqual":function(v){strictEqual=v},"deepEqual":function(v){deepEqual=v}},0);
+"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
 
 
 

--- a/test/output/mixed-keys/actual.js
+++ b/test/output/mixed-keys/actual.js
@@ -1,0 +1,2 @@
+import { _1, $1 } from "./a";
+import _2, * as $2 from "./a";

--- a/test/output/mixed-keys/expected.js
+++ b/test/output/mixed-keys/expected.js
@@ -1,0 +1,1 @@
+"use strict";var _1,$1;module.importSync("./a",{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.importSync("./a",{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1);

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{"a":function(v){ay=v}},0);var bee;module.importSync("./abc",{"b":function(v){bee=v}},1);var see;module.importSync("./abc",{"c":function(v){see=v}},2);
+"use strict";module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{a:function(v){ay=v}},0);var bee;module.importSync("./abc",{b:function(v){bee=v}},1);var see;module.importSync("./abc",{c:function(v){see=v}},2);
 
 
 

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,3 +1,3 @@
-"use strict";function f() {var a,c;module.importSync("./module",{"a":function(v){a=v},"b":function(v){c=v}},0);
+"use strict";function f() {var a,c;module.importSync("./module",{a:function(v){a=v},b:function(v){c=v}},0);
 
 }


### PR DESCRIPTION
This PR avoids quotes on generated keys and settles on a consistent use of double quotes for generated code.