### PR TITLE
Move transform to its own module.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const assert = require("assert");
+const dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
+
 const FastPath = require("./fast-path.js");
 const getOption = require("./options.js").get;
-const utils = require("./utils.js");
 
 const IEV = require("./import-export-visitor.js");
 const importExportVisitor = new IEV;
@@ -11,7 +11,6 @@ const importExportVisitor = new IEV;
 const AV = require("./assignment-visitor.js");
 const assignmentVisitor = new AV;
 
-const hasOwn = Object.prototype.hasOwnProperty;
 const shebangRegExp = /^#!.*/;
 const importExportRegExp = /\b(?:im|ex)port\b/;
 
@@ -72,32 +71,5 @@ exports.compile = function (code, options) {
 };
 
 exports.transform = function (ast, options) {
-  const importExportOptions = Object.assign({}, options);
-  const rootPath = FastPath.from(ast);
-
-  // Essential so that the AST will be modified.
-  importExportOptions.ast = true;
-
-  importExportVisitor.visit(
-    rootPath,
-    null, // No code to modify.
-    importExportOptions
-  );
-
-  const result = { ast, identical: false };
-
-  if (importExportVisitor.madeChanges) {
-    assignmentVisitor.visit(rootPath, {
-      exportedLocalNames: importExportVisitor.exportedLocalNames,
-      modifyAST: true
-    });
-
-    importExportVisitor.finalizeHoisting();
-
-  } else {
-    // Let the caller know the result is no different from the input.
-    result.identical = true;
-  }
-
-  return result;
+  return dynRequire("./transform.js")(ast, options);
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const FastPath = require("./fast-path.js");
+
+const IEV = require("./import-export-visitor.js");
+const importExportVisitor = new IEV;
+
+const AV = require("./assignment-visitor.js");
+const assignmentVisitor = new AV;
+
+module.exports = function (ast, options) {
+  const importExportOptions = Object.assign({}, options);
+  const rootPath = FastPath.from(ast);
+
+  // Essential so that the AST will be modified.
+  importExportOptions.ast = true;
+
+  importExportVisitor.visit(
+    rootPath,
+    null, // No code to modify.
+    importExportOptions
+  );
+
+  const result = { ast, identical: false };
+
+  if (importExportVisitor.madeChanges) {
+    assignmentVisitor.visit(rootPath, {
+      exportedLocalNames: importExportVisitor.exportedLocalNames,
+      modifyAST: true
+    });
+
+    importExportVisitor.finalizeHoisting();
+
+  } else {
+    // Let the caller know the result is no different from the input.
+    result.identical = true;
+  }
+
+  return result;
+};


### PR DESCRIPTION
Moves the transform method into its own module so that it can be more easily excluded from bundles that don't modify the ast.