### PR TITLE
Another round of cleanup and optimization.

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,7 +1,11 @@
 "use strict";
 
+var GETTER_ERROR = {};
+var NAN = {};
+var UNDEFINED = {};
+
 var entryMap = Object.create(null);
-var hasOwn = Object.prototype.hasOwnProperty;
+var keySalt = 0;
 
 function Entry(id) {
   // Same as module.id for this module.
@@ -24,38 +28,29 @@ Entry.getOrCreate = function (id) {
   return entryMap[id] = entryMap[id] || new Entry(id);
 };
 
-var keySalt = 0;
-function makeUniqueKey() {
-  return Math.random()
-    .toString(36)
-    // Add an incrementing salt to help track key ordering and also
-    // absolutely guarantee we never return the same key twice.
-    .replace("0.", ++keySalt + ":");
-}
-
 Ep.addSetters = function (parent, setters, key) {
-  if (typeof key === "undefined") {
-    // If no key was provided, make a new unique key that won't collide
-    // with any other keys.
-    key = makeUniqueKey();
-  } else {
-    // If a key was provided, make sure it is distinct from keys provided
-    // by other parent modules.
-    key = parent.id + ":" + key;
-  }
-
   var names = Object.keys(setters);
   var nameCount = names.length;
+
+  if (! nameCount) {
+    return;
+  }
+
+  // If no key is provided, make a unique key. Otherwise, make sure the key is
+  // distinct from keys provided by other parent modules.
+  key = typeof key === "undefined"
+    ? makeUniqueKey()
+    : parent.id + ":" + key;
 
   for (var i = 0; i < nameCount; ++i) {
     var name = names[i];
     var setter = setters[name];
     if (typeof setter === "function" &&
-        // Ignore any requests for the exports.__esModule property."
+        // Ignore any requests for the exports.__esModule property.
         name !== "__esModule") {
       setter.parent = parent;
       (this.setters[name] =
-       this.setters[name] || Object.create(null)
+        this.setters[name] || Object.create(null)
       )[key] = setter;
     }
   }
@@ -69,43 +64,28 @@ Ep.addGetters = function (getters) {
     var name = names[i];
     var getter = getters[name];
     if (typeof getter === "function" &&
-        // Ignore any requests for the exports.__esModule property."
+        // Ignore any requests for the exports.__esModule property.
         name !== "__esModule" &&
-        // Should this throw if hasOwn.call(this.getters, name)?
-        ! hasOwn.call(this.getters, name)) {
+        // Should this throw if this.getters[name] exists?
+        ! this.getters[name]) {
       this.getters[name] = getter;
     }
   }
 };
-
-function runModuleSetters(module) {
-  var entry = entryMap[module.id];
-  if (entry) {
-    entry.runModuleSetters(module);
-  }
-}
 
 Ep.runModuleGetters = function (module) {
   var names = Object.keys(this.getters);
   var nameCount = names.length;
 
   for (var i = 0; i < nameCount; ++i) {
-    this.runGetter(module, names[i]);
-  }
-};
+    var name = names[i];
+    var value = runGetter(this, name);
 
-// Returns true iff the getter updated module.exports with a new value.
-Ep.runGetter = function (module, name) {
-  if (hasOwn.call(this.getters, name)) {
-    try {
-      // Update module.exports[name] with the current value so that CommonJS
-      // require calls remain consistent with module.importSync.
-      return module.exports[name] =
-        this.getters[name].call(module);
-
-    } catch (e) {
-      // If the getter threw an exception, avoid updating module.exports
-      // and return undefined.
+    // If the getter is run without error, update module.exports[name] with
+    // the current value so that CommonJS require calls remain consistent with
+    // module.importSync.
+    if (value !== GETTER_ERROR) {
+      module.exports[name] = value;
     }
   }
 };
@@ -113,100 +93,121 @@ Ep.runGetter = function (module, name) {
 // Called whenever module.exports might have changed, to trigger any
 // setters associated with the newly exported values.
 Ep.runModuleSetters = function (module) {
-  var entry = this;
-  var names = Object.keys(this.setters);
-
   // Make sure module.exports is up to date before we call
   // module.getExportByName(name).
   this.runModuleGetters(module);
 
-  if (! names.length) {
-    ++this.runCount;
-    return;
-  }
-
-  // Invoke the given callback once for every (setter, value, name) triple
-  // that needs to be called. Note that forEachSetter does not call any
-  // setters itself, only the given callback.
-  function forEachSetter(callback, context) {
-    var nameCount = names.length;
-
-    for (var i = 0; i < nameCount; ++i) {
-      var name = names[i];
-      var setters = entry.setters[name];
-      var keys = Object.keys(setters);
-      var keyCount = keys.length;
-
-      for (var j = 0; j < keyCount; ++j) {
-        var key = keys[j];
-        var value = module.getExportByName(name);
-
-        if (name === "*") {
-          var valueNames = Object.keys(value);
-          var valueNameCount = valueNames.length;
-
-          for (var k = 0; k < valueNameCount; ++k) {
-            var valueName = valueNames[k];
-            call(setters[key], value[valueName], valueName);
-          }
-
-        } else {
-          call(setters[key], value, name);
-        }
-      }
-    }
-
-    function call(setter, value, name) {
-      if (name === "__esModule") {
-        // Ignore setters asking for module.exports.__esModule.
-        return;
-      }
-
-      setter.last = setter.last || Object.create(null);
-
-      if (! hasOwn.call(setter.last, name) ||
-          setter.last[name] !== value) {
-        // Only invoke the callback if we have not called this setter
-        // (with a value of this name) before, or the current value is
-        // different from the last value we passed to this setter.
-        return callback.apply(context, arguments);
-      }
-    }
-  }
-
   // Lazily-initialized object mapping parent module identifiers to parent
   // module objects whose setters we might need to run.
-  var relevantParents;
+  var parents;
 
   // Take snapshots of setter.parent.exports for any setters that we are
   // planning to call, so that we can later determine if calling the
   // setters modified any of those exports objects.
-  forEachSetter(function (setter, value, name) {
-    relevantParents = relevantParents || Object.create(null);
-    relevantParents[setter.parent.id] = setter.parent;
-    setter.call(module, setter.last[name] = value, name);
+  forEachSetter(module, this, function (setter, name, value) {
+    parents = parents || Object.create(null);
+    parents[setter.parent.id] = setter.parent;
+
+    // The param order for setters is `value` then `name` because the `name`
+    // param is only used by namespace exports.
+    setter(value, name);
   });
 
-  ++entry.runCount;
+  ++this.runCount;
 
-  if (! relevantParents) {
+  if (! parents) {
     return;
   }
 
   // If any of the setters updated the module.exports of a parent module,
   // or updated local variables that are exported by that parent module,
   // then we must re-run any setters registered by that parent module.
-
-  var parentIDs = Object.keys(relevantParents);
+  var parentIDs = Object.keys(parents);
   var parentIDCount = parentIDs.length;
 
   for (var i = 0; i < parentIDCount; ++i) {
-    // What happens if relevantParents[parentIDs[id]] === module, or if
+    // What happens if parents[parentIDs[id]] === module, or if
     // longer cycles exist in the parent chain? Thanks to our setter.last
     // bookkeeping above, the runModuleSetters broadcast will only proceed
     // as far as there are any actual changes to report.
-    runModuleSetters(relevantParents[parentIDs[i]]);
+    var parent = parents[parentIDs[i]];
+    var entry = entryMap[parent.id];
+    if (entry) {
+      entry.runModuleSetters(parent);
+    }
   }
 };
+
+function call(setter, name, value, callback) {
+  if (name === "__esModule") {
+    // Ignore setters asking for module.exports.__esModule.
+    return;
+  }
+
+  var valueToCompare = value;
+  if (valueToCompare !== valueToCompare) {
+    valueToCompare = NAN;
+  } else if (typeof valueToCompare === "undefined") {
+    valueToCompare = UNDEFINED;
+  }
+
+  setter.last = setter.last || Object.create(null);
+
+  if (setter.last[name] !== valueToCompare) {
+    // Only invoke the callback if we have not called this setter
+    // (with a value of this name) before, or the current value is
+    // different from the last value we passed to this setter.
+    setter.last[name] = valueToCompare;
+    return callback(setter, name, value);
+  }
+}
+
+// Invoke the given callback once for every (setter, value, name) triple
+// that needs to be called. Note that forEachSetter does not call any
+// setters itself, only the given callback.
+function forEachSetter(module, entry, callback) {
+  var names = Object.keys(entry.setters);
+  var nameCount = names.length;
+
+  for (var i = 0; i < nameCount; ++i) {
+    var name = names[i];
+    var setters = entry.setters[name];
+    var keys = Object.keys(setters);
+    var keyCount = keys.length;
+
+    for (var j = 0; j < keyCount; ++j) {
+      var key = keys[j];
+      var value = module.getExportByName(name);
+
+      if (name === "*") {
+        var valueNames = Object.keys(value);
+        var valueNameCount = valueNames.length;
+
+        for (var k = 0; k < valueNameCount; ++k) {
+          var valueName = valueNames[k];
+          call(setters[key], valueName, value[valueName], callback);
+        }
+
+      } else {
+        call(setters[key], name, value, callback);
+      }
+    }
+  }
+}
+
+function makeUniqueKey() {
+  return Math.random()
+    .toString(36)
+    // Add an incrementing salt to help track key ordering and also
+    // absolutely guarantee we never return the same key twice.
+    .replace("0.", ++keySalt + ":");
+}
+
+function runGetter(entry, name) {
+  try {
+    return entry.getters[name]();
+  } catch (e) {}
+  return GETTER_ERROR;
+}
 
 module.exports = Entry;

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var __esSymbol = typeof Symbol === "function" ? Symbol.for("__esModule") : null;
 var hasOwn = Object.prototype.hasOwnProperty;
 var Entry = require("./entry.js");
 
@@ -48,20 +49,6 @@ exports.enable = function (Module) {
     // assignment, and does not interfere with the larger computation.
     return valueToPassThrough;
   };
-
-  function setESModule(module) {
-    var exports = module.exports;
-    if (exports &&
-        typeof exports === "object" &&
-        ! hasOwn.call(exports, "__esModule")) {
-      Object.defineProperty(exports, "__esModule", {
-        value: true,
-        enumerable: false,
-        writable: false,
-        configurable: true
-      });
-    }
-  }
 
   // If key is provided, it will be used to identify the given setters so
   // that they can be replaced if module.importSync is called again with the
@@ -125,13 +112,39 @@ exports.enable = function (Module) {
     if (name === "default" &&
         ! (exports &&
            typeof exports === "object" &&
-           exports.__esModule &&
+           (hasOwn.call(exports, "__esModule") ||
+             (__esSymbol && hasOwn.call(exports, __esSymbol))) &&
            "default" in exports)) {
       return exports;
     }
 
-    return exports && exports[name];
+    if (exports == null) {
+      return;
+    }
+
+    return exports[name];
   };
 
   return Module;
 };
+
+function setESModule(module) {
+  var exports = module.exports;
+  if (exports &&
+      typeof exports === "object" &&
+      ! hasOwn.call(exports, "__esModule") &&
+      ! (__esSymbol && hasOwn.call(exports, __esSymbol))) {
+
+    if (__esSymbol) {
+      exports[__esSymbol] = true;
+    } else {
+      Object.defineProperty(exports, "__esModule", {
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: true
+      });
+    }
+
+  }
+}

--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -35,9 +35,9 @@ if (! _compile.reified) {
 }
 
 const exts = Module._extensions;
-const _extMjs = exts[".mjs"];
-if (! (_extMjs && _extMjs.reified)) {
+const extMjs = exts[".mjs"];
+if (! (extMjs && extMjs.reified)) {
   (exts[".mjs"] = (module, filename) =>
     exts[".js"](module, filename)
-  ).reified = _extMjs;
+  ).reified = extMjs;
 }

--- a/test/export/common.js
+++ b/test/export/common.js
@@ -5,5 +5,5 @@ import { strictEqual } from "assert";
 module.exports = "pure CommonJS";
 
 // The import statement above should have been compiled to a
-// module.importSync call, which sets exports.__esModule = true.
-strictEqual(exports.__esModule, true);
+// module.importSync call, which sets exports[Symbol.for("__esModule")] = true.
+strictEqual(exports[Symbol.for("__esModule")], true);


### PR DESCRIPTION
 * Move functions out of others in lib/entry and lib/runtime
 * Align `extMjs` var name with convention in node/compile-hook
 * Use `UNDEFINED` and `NAN` objects in place of literals for setter cache in lib/entry
 * Use a symbol as an "__esModule" flag for better runtime performance