### PR TITLE
Avoid double reads when loading cached files.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -16,6 +16,8 @@ const importExportRegExp = /\b(?:im|ex)port\b/;
 
 exports.compile = function (code, options) {
   code = code.replace(shebangRegExp, "");
+  options = Object.assign(Object.create(null), options);
+
   const parse = getOption(options, "parse");
   const ast = parse(code);
 
@@ -54,7 +56,6 @@ exports.compile = function (code, options) {
   }
 
   result.code = magicString.toString();
-
   return result;
 };
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -2,21 +2,19 @@
 
 const hasOwn = Object.prototype.hasOwnProperty;
 
-const defaultCompileOptions = {
+const defaultOptions = {
   ast: false,
-  force: false,
-  generateLetDeclarations: false,
   // If not false, "use strict" will be added to any modules with at least
   // one import or export declaration.
   enforceStrictMode: true,
+  force: false,
+  generateLetDeclarations: false,
   get parse () {
     return require("./parsers/default.js").parse;
   }
 };
 
 exports.get = function (options, name) {
-  if (options && hasOwn.call(options, name)) {
-    return options[name];
-  }
-  return defaultCompileOptions[name];
+  const result = hasOwn.call(options, name) ? options[name] : undefined;
+  return typeof result === "undefined" ? defaultOptions[name] : result;
 };

--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -1,41 +1,77 @@
 "use strict";
 
 const compiler = require("./caching-compiler.js");
+const path = require("path");
 const utils = require("./utils.js");
 
 const Module = require("./runtime.js").Module;
+const exts = Module._extensions;
 const Mp = Module.prototype;
 
-let overrideCompileOptions = {};
+let compileOptions;
 
 module.exports = exports = (options) => {
-  overrideCompileOptions = Object.assign({}, options);
+  if (typeof compileOptions === "undefined") {
+    compileOptions = Object.assign({}, options);
+  }
 };
+
+function getCacheKey(filename) {
+  const mtime = utils.mtime(filename);
+  if (mtime === -1) {
+    return null;
+  }
+  return {
+    filename,
+    mtime,
+    source: "Module.prototype._compile"
+  };
+}
 
 // Override Module.prototype._compile to compile any code that will be
 // evaluated as a module.
 const _compile = Mp._compile;
 if (! _compile.reified) {
   (Mp._compile = function (content, filename) {
-    return _compile.call(
-      this,
-      compiler.compile(content, Object.assign({
-        filename,
-        makeCacheKey() {
-          const stat = utils.statOrNull(filename);
-          return stat && {
-            filename,
-            mtime: stat.mtime.getTime(),
-            source: "Module.prototype._compile"
-          };
-        }
-      }, overrideCompileOptions)),
-      filename
-    );
+    const options = {
+      filename,
+      cacheKey() {
+        return getCacheKey(filename);
+      }
+    };
+
+    content = compiler.compile(content, Object.assign(options, compileOptions));
+    return _compile.call(this, content, filename);
   }).reified = _compile;
 }
 
-const exts = Module._extensions;
+const extJs = exts[".js"];
+if (! (extJs && extJs.reified)) {
+  (exts[".js"] = (module, filename) => {
+    const pkgInfo = typeof filename === "string"
+      ? utils.getPkgInfo(path.dirname(filename))
+      : null;
+
+    const cachePath = pkgInfo !== null ? pkgInfo.cachePath : null;
+    if (typeof cachePath === "string") {
+      const cache = pkgInfo.cache;
+      const cacheKey = getCacheKey(filename);
+      const cacheFilename = utils.getCacheFilename(cacheKey, pkgInfo.config);
+
+      let cacheValue = cache[cacheFilename];
+      if (cacheValue === true) {
+        const cacheFilepath = path.join(cachePath, cacheFilename);
+        const buffer = utils.readFile(cacheFilepath);
+        cacheValue = cache[cacheFilename] = utils.gunzip(buffer, "utf8");
+      }
+      if (typeof cacheValue === "string") {
+        return module._compile(cacheValue, filename);
+      }
+    }
+    return extJs(module, filename);
+  }).reified = extJs;
+}
+
 const extMjs = exts[".mjs"];
 if (! (extMjs && extMjs.reified)) {
   (exts[".mjs"] = (module, filename) =>

--- a/node/utils.js
+++ b/node/utils.js
@@ -1,12 +1,37 @@
 "use strict";
 
 const createHash = require("crypto").createHash;
-const dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
 const fs = require("fs");
 const path = require("path");
+const zlib = require("minizlib");
 
-const DEFAULT_CACHE_DIR = ".reify-cache";
+const DEFAULT_GZIP_CONFIG = {
+  level: 9
+};
+
+const DEFAULT_PKG_CONFIG = {
+  "cache-directory": ".reify-cache",
+  parser: undefined
+};
+
+const fsBinding = (() => {
+  try {
+    return process.binding("fs");
+  } catch (e) {}
+  return Object.create(null);
+})();
+
 const hasOwn = Object.prototype.hasOwnProperty;
+const nodeVersion = +process.version.match(/\d+/);
+
+const internalModuleReadFile = fsBinding.internalModuleReadFile;
+const internalModuleStat = fsBinding.internalModuleStat;
+const internalStat = nodeVersion > 5 ? fsBinding.stat : undefined;
+const internalStatValues = fsBinding.getStatValues;
+
+let useIsDirectoryFastPath = typeof internalModuleStat === "function";
+let useMtimeFastPath = typeof internalStat === "function";
+let useReadFileFastPath = typeof internalModuleReadFile === "function";
 
 let pendingWriteTimer;
 const pendingWrites = Object.create(null);
@@ -14,10 +39,12 @@ const pendingWrites = Object.create(null);
 // Map from absolute file paths to the package.json that governs them.
 const pkgInfoCache = Object.create(null);
 
+const reifyPkgPath = path.join(__dirname, "../package.json");
+
 const reifyVersion = (() => {
   const parts = (
     process.env.REIFY_VERSION ||
-    dynRequire("../package.json").version
+    readJSON(reifyPkgPath).version
   ).split(".");
 
   return {
@@ -27,193 +54,283 @@ const reifyVersion = (() => {
   };
 })();
 
-function checkReify(pkg, name) {
-  var entry = pkg[name];
+const statValues = typeof internalStatValues === "function"
+  ? internalStatValues()
+  : new Float64Array(14);
+
+function checkReify(json, name) {
+  var entry = json[name];
   return typeof entry === "object" && entry !== null && hasOwn.call(entry, "reify");
 }
 
-function getCacheFilename() {
-  const argCount = arguments.length;
-  const strings = new Array(argCount);
+function fallbackIsDirectory(filepath) {
+  try {
+    return fs.statSync(filepath).isDirectory();
+  } catch (e) {}
+  return false;
+}
 
-  for (let i = 0; i < argCount; ++i) {
-    const arg = arguments[i];
-    if (typeof arg === "string") {
-      strings[i] = arg;
-    } else {
-      strings[i] = JSON.stringify(arg);
-    }
-  }
+function fallbackMtime(filepath) {
+  try {
+    return fs.statSync(filepath).mtime.getTime();
+  } catch (e) {}
+  return -1;
+}
 
+function fallbackReadFile(filepath, options) {
+  try {
+    return fs.readFileSync(filepath, options);
+  } catch (e) {}
+  return null;
+}
+
+function streamToBuffer(stream, data) {
+  const result = [];
+  stream.on("data", chunk => result.push(chunk)).end(data);
+  return Buffer.concat(result);
+}
+
+function getCacheFilename(cacheKey, pkgCfg) {
+  // Take only the major and minor components of the reify version, so that
+  // we don't invalidate the cache every time a patch version is released.
   return createHash("sha1")
-    // Take only the major and minor components of the reify version, so that
-    // we don't invalidate the cache every time a patch version is released.
     .update(reifyVersion.major + "." + reifyVersion.minor)
     .update("\0")
-    .update(strings.join("\0"))
-    .digest("hex") + ".js";
+    .update(
+      typeof cacheKey === "object" && cacheKey !== null
+        ? JSON.stringify(cacheKey)
+        : cacheKey
+    )
+    .update("\0")
+    .update(JSON.stringify(pkgCfg))
+    .update("\0")
+    .digest("hex") + ".js.gz";
 }
 
 exports.getCacheFilename = getCacheFilename;
 
-function getPkgInfo(filename) {
-  if (pkgInfoCache[filename]) {
-    return pkgInfoCache[filename];
+function getPkgInfo(dirpath) {
+  if (typeof pkgInfoCache[dirpath] !== "undefined") {
+    return pkgInfoCache[dirpath];
   }
 
-  pkgInfoCache[filename] = null;
+  pkgInfoCache[dirpath] = null;
 
-  const stat = statOrNull(filename);
-  if (! stat) {
+  if (path.basename(dirpath) === "node_modules") {
     return null;
   }
 
-  if (stat.isDirectory()) {
-    if (path.basename(filename) === "node_modules") {
-      return null;
-    }
-
-    const pkgInfo = readPkgInfo(filename);
-    if (pkgInfo) {
-      return pkgInfoCache[filename] = pkgInfo;
-    }
+  const pkgInfo = readPkgInfo(dirpath);
+  if (pkgInfo !== null) {
+    return pkgInfoCache[dirpath] = pkgInfo;
   }
 
-  const parentDir = path.dirname(filename);
-
-  if (parentDir !== filename) {
-    return pkgInfoCache[filename] = getPkgInfo(parentDir);
+  const parentPath = path.dirname(dirpath);
+  if (parentPath !== dirpath) {
+    const pkgInfo = getPkgInfo(parentPath);
+    if (pkgInfo !== null) {
+      return pkgInfoCache[dirpath] = pkgInfo;
+    }
   }
   return null;
 }
 
 exports.getPkgInfo = getPkgInfo;
 
-function mkdirp(rootDir, relativeDir) {
-  const parentDir = path.dirname(relativeDir);
-  if (parentDir === relativeDir) {
-    return rootDir;
-  }
+function gzip(data, options) {
+  options = Object.assign(Object.create(null), DEFAULT_GZIP_CONFIG, options);
+  return streamToBuffer(new zlib.Gzip(options), data);
+}
 
-  if (! mkdirp(rootDir, parentDir)) {
-    return null;
-  }
+exports.gzip = gzip;
 
-  const absoluteDir = path.join(rootDir, relativeDir);
-  const stat = statOrNull(absoluteDir);
-  if (stat && stat.isDirectory()) {
-    return absoluteDir;
-  }
+function gunzip(data, options) {
+  options = typeof options === "string" ? { encoding: options } : options;
+  options = Object.assign(Object.create(null), options);
 
+  const stream = new zlib.Gunzip(options);
+  if (options.encoding !== "utf8") {
+    return streamToBuffer(stream, data);
+  }
+  let result = "";
+  stream.on("data", chunk => result += chunk).end(data);
+  return result;
+}
+
+exports.gunzip = gunzip;
+
+function isDirectory(thepath) {
+  if (useIsDirectoryFastPath) {
+    try {
+      // Used to speed up loading. Returns 0 if the path refers to a file,
+      // 1 when it's a directory or < 0 on error (usually ENOENT). The speedup
+      // comes from not creating thousands of Stat and Error objects.
+      return internalModuleStat(thepath) === 1;
+    } catch (e) {
+      useIsDirectoryFastPath = false;
+    }
+  }
+  return fallbackIsDirectory(thepath);
+}
+
+exports.isDirectory = isDirectory;
+
+function mkdir(dirpath) {
   try {
-    fs.mkdirSync(absoluteDir);
-  } catch (e) {
-    return null;
-  }
+    fs.mkdirSync(dirpath);
+    return true;
+  } catch (e) {}
+  return false;
+}
 
-  return absoluteDir;
+exports.mkdir = mkdir;
+
+function mkdirp(rootPath, relativePath) {
+  const parentPath = path.dirname(relativePath);
+  if (parentPath === relativePath) {
+    return true;
+  }
+  if (mkdirp(rootPath, parentPath)) {
+    const absolutePath = path.join(rootPath, relativePath);
+    return isDirectory(absolutePath) || mkdir(absolutePath);
+  }
+  return false;
 }
 
 exports.mkdirp = mkdirp;
 
-function readFileOrNull(filename) {
+function mtime(filepath) {
+  if (useMtimeFastPath) {
+    try {
+      // Used to speed up file stats. Modifies the `statValues` typed array,
+      // with index 11 being the mtime milliseconds stamp. The speedup comes
+      // from not creating Stat objects.
+      if (internalStatValues) {
+        internalStat(filepath);
+      } else {
+        internalStat(filepath, statValues);
+      }
+      return statValues[11];
+    } catch (e) {
+      if (e.code === "ENOENT") {
+        return -1;
+      }
+      useMtimeFastPath = false;
+    }
+  }
+  return fallbackMtime(filepath);
+}
+
+exports.mtime = mtime;
+
+function readdir(dirpath) {
   try {
-    return fs.readFileSync(filename, "utf8");
+    return fs.readdirSync(dirpath);
   } catch (e) {}
   return null;
 }
 
-exports.readFileOrNull = readFileOrNull;
+exports.readdir = readdir;
 
-function readPkgInfo(dir) {
-  const pkg = (() => {
+function readFile(filepath, options) {
+  const encoding = typeof options === "object" && options !== null
+    ? options.encoding
+    : options;
+
+  if (useReadFileFastPath && encoding === "utf8") {
     try {
-      return dynRequire(path.join(dir, "package.json"));
-    } catch (e) {}
-    return null;
-  })();
+      // Used to speed up reading. Returns the contents of the file as a string
+      // or undefined when the file cannot be opened. The speedup comes from not
+      // creating Error objects on failure.
+      const content = internalModuleReadFile(filepath);
+      return typeof content === "undefined" ? null : content;
+    } catch (e) {
+      useReadFileFastPath = false;
+    }
+  }
+  return fallbackReadFile(filepath, options);
+}
 
-  if (! pkg) {
+exports.readFile = readFile;
+
+function readJSON(filepath) {
+  const content = readFile(filepath, "utf8");
+  return content === null ? content : JSON.parse(content);
+}
+
+exports.readJSON = readJSON;
+
+function readPkgInfo(dirpath) {
+  const pkg = readJSON(path.join(dirpath, "package.json"));
+  if (pkg === null) {
     return null;
   }
 
-  const reify = pkg.reify == null ? {} : pkg.reify;
-
+  const reify = pkg.reify;
   if (reify === false) {
     // An explicit "reify": false property in package.json disables
     // reification even if "reify" is listed as a dependency.
     return null;
   }
-
   if (! checkReify(pkg, "dependencies") &&
-      ! checkReify(pkg, "peerDependencies") &&
       // Use case: a package.json file may have "reify" in its
       // "devDependencies" section because it expects another package or
       // application to enable reification in production, but needs its
       // own copy of the "reify" package during development. Disabling
       // reification in production when it was enabled in development
       // would be dangerous in this case.
-      ! checkReify(pkg, "devDependencies")) {
+      ! checkReify(pkg, "devDependencies") &&
+      ! checkReify(pkg, "peerDependencies")) {
     return null;
   }
 
+  const config = Object.assign(Object.create(null), DEFAULT_PKG_CONFIG, reify);
+  const cacheDir = config["cache-directory"];
+  const cachePath = typeof cacheDir === "string" ? path.join(dirpath, cacheDir) : null;
+  const cacheFiles = cachePath !== null ? readdir(cachePath) : null;
+
   const pkgInfo = {
     cache: Object.create(null),
-    cacheDir: null,
-    json: pkg
+    cachePath,
+    config
   };
 
-  const cacheDirName = hasOwn.call(reify, "cache-directory")
-    ? reify["cache-directory"]
-    : DEFAULT_CACHE_DIR;
+  const fileCount = cacheFiles !== null ? cacheFiles.length : 0;
 
-  const cacheDir = typeof cacheDirName === "string"
-    ? mkdirp(dir, cacheDirName)
-    : null;
-
-  const cacheFiles = cacheDir
-    ? fs.readdirSync(cacheDir)
-    : null;
-
-  if (cacheFiles) {
-    // If we leave pkgInfo.cacheDir === null, we won't be able to
-    // save cache files to disk, but we can still cache compilation
-    // results in memory.
-    pkgInfo.cacheDir = cacheDir;
-
-    const filesCount = cacheFiles.length;
-
-    for (let i = 0; i < filesCount; ++i) {
-      // Later we'll change the value to the actual contents of the
-      // file, but for now we merely register that it exists.
-      pkgInfo.cache[cacheFiles[i]] = true;
-    }
+  for (let i = 0; i < fileCount; ++i) {
+    // Later, in Module._extensions[".js"], we'll change the value to the actual
+    // contents of the file, but for now we merely register that it exists.
+    pkgInfo.cache[cacheFiles[i]] = true;
   }
-
   return pkgInfo;
 }
 
 exports.readPkgInfo = readPkgInfo;
 
-function scheduleWrite(path, content) {
-  pendingWrites[path] = content;
-  pendingWriteTimer = pendingWriteTimer || setTimeout(() => {
+function scheduleWrite(rootPath, relativePath, content) {
+  const filepath = path.join(rootPath, relativePath);
+  pendingWrites[filepath] = { content, rootPath, relativePath };
+  pendingWriteTimer = pendingWriteTimer || setImmediate(() => {
     pendingWriteTimer = null;
-    Object.keys(pendingWrites).forEach((path) => {
-      const content = pendingWrites[path];
-      delete pendingWrites[path];
-      fs.writeFileSync(path, content, "utf8");
+    Object.keys(pendingWrites).forEach((filepath) => {
+      const pending = pendingWrites[filepath];
+
+      if (mkdirp(pending.rootPath, path.dirname(pending.relativePath)) &&
+          writeFile(filepath, gzip(pending.content))) {
+        delete pendingWrites[filepath];
+      }
     });
-  }, 10);
+  });
 }
 
 exports.scheduleWrite = scheduleWrite;
 
-function statOrNull(filename) {
+function writeFile(filepath, data, options) {
   try {
-    return fs.statSync(filename);
+    fs.writeFileSync(filepath, data, options);
+    return true;
   } catch (e) {}
-  return null;
+  return false;
 }
 
-exports.statOrNull = statOrNull;
+exports.writeFile = writeFile;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test": "test/run.sh"
   },
   "dependencies": {
-    "acorn": "~5.0.0"
+    "acorn": "~5.0.0",
+    "minizlib": "^1.0.2"
   },
   "devDependencies": {
     "babel-core": "^6.24.0",


### PR DESCRIPTION
This PR addresses #141 by avoiding double reading of cache files, safely *(with fallbacks)* uses optimized internal helpers for reading and stating files, reduces memory a bit by storing less package.json data, defers creating cache directories until cache files are being written to, and reduces unnecessary crawling by a level.