### PR TITLE
Use a smarter importExportRegExp to avoid recompilation.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,7 +12,13 @@ const AV = require("./assignment-visitor.js");
 const assignmentVisitor = new AV;
 
 const shebangRegExp = /^#!.*/;
-const importExportRegExp = /\b(?:im|ex)port\b/;
+
+// Matches any import or export identifier as long as it's not preceded by
+// a `.` character (to avoid matching module.export, for example). Because
+// Reify replaces all import and export declarations with module.import
+// and module.export calls, this logic should prevent the compiler from
+// ever having to recompile code it has already compiled.
+const importExportRegExp = /(?:^|[^.])\b(?:im|ex)port\b/;
 
 exports.compile = function (code, options) {
   code = code.replace(shebangRegExp, "");


### PR DESCRIPTION
The compiler uses `importExportRegExp` to check quickly whether a string of code contains anything that looks like an `import` or `export` keyword, so it can avoid parsing, AST transformation, etc. when there's clearly no work to do.

A particularly important source of false positives was that the compiler itself generates `module.importSync` and `module.export` calls to replace `import` and `export` declarations. Since `/\b(?:im|ex)port\b/.test("module.export(...)")` is true, the compiler would go ahead and recompile code that contained `module.export` expressions (`module.import` is no longer as much of a problem since we renamed it to `module.importSync` in #85).

By changing `/\b(?:im|ex)port\b/` to `/(?:^|[^.])\b(?:im|ex)port\b/`, we can exclude matches that are preceded by a `.` character, which means the compiler should never recompile code that it previously compiled (unless there were other false positives that were not replaced, which is beyond the scope of the quick-and-dirty `importExportRegExp` check).