### PR TITLE
Cleanup acorn-extensions.

### DIFF
--- a/lib/parsers/acorn-extensions.js
+++ b/lib/parsers/acorn-extensions.js
@@ -3,8 +3,13 @@
 const tt = require("acorn").tokTypes;
 
 exports.enableAll = function (parser) {
-  exports.enableTolerance(parser);
   exports.enableExportExtensions(parser);
+  exports.enableTolerance(parser);
+};
+
+exports.enableExportExtensions = function (parser) {
+  parser.checkExports = checkExports;
+  parser.parseExport = parseExport;
 };
 
 exports.enableTolerance = function (parser) {
@@ -15,154 +20,175 @@ exports.enableTolerance = function (parser) {
   parser.raiseRecoverable = noopRaiseRecoverable;
 };
 
+function checkExports(exports, name) {
+  if (exports !== void 0) {
+    exports[name] = true;
+  }
+}
+
+function isCommaOrFrom(parser) {
+  return parser.type === tt.comma || parser.isContextual("from");
+}
+
+function isExportDefaultSpecifier(parser) {
+  return parser.type === tt.name &&
+    withLookAhead(parser, 1, isCommaOrFrom);
+}
+
 function noopRaiseRecoverable() {}
-
-exports.enableExportExtensions = function (parser) {
-  // Our custom lookahead method.
-  parser.withLookAhead = withLookAhead;
-
-  // Export-related modifications.
-  parser.parseExport = parseExport;
-  parser.isExportDefaultSpecifier = isExportDefaultSpecifier;
-  parser.parseExportSpecifiersMaybe = parseExportSpecifiersMaybe;
-  parser.parseExportFrom = parseExportFrom;
-  parser.shouldParseExportDeclaration = shouldParseExportDeclaration;
-};
 
 function parseExport(node, exports) {
   this.next();
+
   if (this.type === tt.star) {
-    const specifier = this.startNode();
-    this.next();
-    if (this.eatContextual("as")) {
-      // export * as ns from '...'
-      specifier.exported = this.parseIdent(true);
-      node.specifiers = [
-        this.finishNode(specifier, "ExportNamespaceSpecifier")
-      ];
-      this.parseExportSpecifiersMaybe(node);
-      this.parseExportFrom(node, exports);
-    } else {
-      // export * from '...'
-      this.parseExportFrom(node, exports);
-      return this.finishNode(node, "ExportAllDeclaration");
-    }
-  } else if (this.isExportDefaultSpecifier()) {
-    // export def from '...'
-    const specifier = this.startNode();
-    specifier.exported = this.parseIdent(true);
-    node.specifiers = [
-      this.finishNode(specifier, "ExportDefaultSpecifier")
-    ];
-    if (this.type === tt.comma &&
-        peekNextType(this) === tt.star) {
-      // export def, * as ns from '...'
-      this.expect(tt.comma);
-      const specifier = this.startNode();
-      this.expect(tt.star);
-      this.expectContextual("as");
-      specifier.exported = this.parseIdent(true);
-      node.specifiers.push(
-        this.finishNode(specifier, "ExportNamespaceSpecifier")
-      );
-    } else {
-      // export def, { x, y as z } from '...'
-      this.parseExportSpecifiersMaybe(node);
-    }
-    this.parseExportFrom(node, exports);
-  } else if (this.eat(tt._default)) {
-    // export default ...
-    exports.default = true;
-    let isAsync;
-    if (this.type === tt._function || (isAsync = this.isAsyncFunction())) {
-      let fNode = this.startNode();
-      this.next();
-      if (isAsync) this.next();
-      node.declaration = this.parseFunction(fNode, "nullableID", false, isAsync);
-    } else if (this.type === tt._class) {
-      let cNode = this.startNode();
-      node.declaration = this.parseClass(cNode, "nullableID");
-    } else {
-      node.declaration = this.parseMaybeAssign();
-      this.semicolon();
-    }
-    return this.finishNode(node, "ExportDefaultDeclaration");
-  } else if (this.shouldParseExportDeclaration()) {
-    // export var|const|let|function|class ...
-    node.declaration = this.parseStatement(true);
-    if (node.declaration.type === "VariableDeclaration") {
-      this.checkVariableExport(exports, node.declaration.declarations);
-    } else {
-      exports[node.declaration.id.name] = true;
-    }
-    node.specifiers = [];
-    node.source = null;
-  } else {
-    // export { x, y as z } [from '...']
-    node.declaration = null;
-    node.specifiers = this.parseExportSpecifiers(exports);
-    this.parseExportFrom(node, exports);
+    return parseExportNamespaceSpecifiersAndSource(this, node, exports);
   }
-  return this.finishNode(node, "ExportNamedDeclaration");
+  if (isExportDefaultSpecifier(this)) {
+    return parseExportDefaultSpecifiersAndSource(this, node, exports);
+  }
+  if (this.eat(tt._default)) {
+    return parseExportDefaultDeclaration(this, node, exports);
+  }
+  if (this.shouldParseExportStatement()) {
+    return parseExportNamedDeclaration(this, node, exports);
+  }
+  return parseExportSpecifiersAndSource(this, node, exports);
+}
+
+function parseExportDefaultDeclaration(parser, node, exports) {
+  // export default ...;
+  exports.default = true;
+
+  let isAsync;
+  if (parser.type === tt._function || (isAsync = parser.isAsyncFunction())) {
+    const funcNode = parser.startNode();
+    if (isAsync) {
+      parser.next();
+    }
+    parser.next();
+    node.declaration = parser.parseFunction(funcNode, "nullableID", false, isAsync);
+  } else if (parser.type === tt._class) {
+    const classNode = parser.startNode();
+    node.declaration = parser.parseClass(classNode, "nullableID");
+  } else {
+    node.declaration = parser.parseMaybeAssign();
+  }
+  parser.semicolon();
+  return parser.finishNode(node, "ExportDefaultDeclaration");
+}
+
+function parseExportDefaultSpecifiersAndSource(parser, node, exports) {
+  // export def from '...';
+  const specifier = parser.startNode();
+  specifier.exported = parser.parseIdent(true);
+
+  node.specifiers = [
+    parser.finishNode(specifier, "ExportDefaultSpecifier")
+  ];
+
+  if (parser.type === tt.comma &&
+      peekNextType(parser) === tt.star) {
+    // export def, * as ns from '...';
+    parser.next();
+    const specifier = parser.startNode();
+    parser.next();
+    parseExportNamespaceSpecifiers(parser, node, specifier, exports);
+  }
+  // export def, * as ns [, { x, y as z }] from '...';
+  parseExportSpecifiersMaybe(parser, node);
+
+  parseExportFrom(parser, node);
+  return parser.finishNode(node, "ExportNamedDeclaration");
+}
+
+function parseExportFrom(parser, node) {
+  parser.expectContextual("from");
+  node.source = parser.type === tt.string ? parser.parseExprAtom() : null;
+  parser.semicolon();
+}
+
+function parseExportNamedDeclaration(parser, node, exports) {
+  // export var|const|let|function|class ...
+  node.declaration = parser.parseStatement(true);
+  node.source = null;
+  node.specifiers = [];
+
+  if (node.declaration.type === "VariableDeclaration") {
+    parser.checkVariableExport(exports, node.declaration.declarations);
+  } else {
+    exports[node.declaration.id.name] = true;
+  }
+  return parser.finishNode(node, "ExportNamedDeclaration");
+}
+
+function parseExportNamespaceSpecifiers(parser, node, specifier, exports) {
+  parser.expectContextual("as");
+  specifier.exported = parser.parseIdent(true);
+  node.specifiers.push(
+    parser.finishNode(specifier, "ExportNamespaceSpecifier")
+  );
+
+  exports[specifier.exported.name] = true;
+}
+
+function parseExportNamespaceSpecifiersAndSource(parser, node, exports) {
+  const specifier = parser.startNode();
+
+  node.specifiers = [];
+  parser.next();
+
+  if (! parser.isContextual("as")) {
+    // export * from '...';
+    parseExportFrom(parser, node);
+    return parser.finishNode(node, "ExportAllDeclaration");
+  }
+  // export * as ns from '...';
+  parseExportNamespaceSpecifiers(parser, node, specifier, exports);
+  // export * as ns[, { x, y as z }] from '...';
+  parseExportSpecifiersMaybe(parser, node);
+
+  parseExportFrom(parser, node);
+  return parser.finishNode(node, "ExportNamedDeclaration");
+}
+
+function parseExportSpecifiersAndSource(parser, node, exports) {
+  // export { x, y as z } [from '...'];
+  node.declaration = null;
+  node.specifiers = parser.parseExportSpecifiers(exports);
+
+  if (parser.isContextual("from")) {
+    parseExportFrom(parser, node, exports);
+  } else {
+    parser.semicolon();
+  }
+  return parser.finishNode(node, "ExportNamedDeclaration");
+}
+
+function parseExportSpecifiersMaybe(parser, node) {
+  if (parser.eat(tt.comma)) {
+    node.specifiers.push.apply(
+      node.specifiers,
+      parser.parseExportSpecifiers()
+    );
+  }
+}
+
+function peekNextType(parser) {
+  return withLookAhead(parser, 1, () => parser.type);
 }
 
 // Calls the given callback with the state of the parser temporarily
 // advanced by calling this.nextToken() n times, then rolls the parser
 // back to its original state and returns whatever the callback returned.
-function withLookAhead(n, callback) {
-  const old = Object.assign(Object.create(null), this);
-  while (n-- > 0) this.nextToken();
+function withLookAhead(parser, n, callback) {
+  if (n < 1) {
+    return;
+  }
+  const old = Object.assign(Object.create(null), parser);
+  while (n--) parser.nextToken();
   try {
-    return callback(this);
+    return callback(parser);
   } finally {
-    Object.assign(this, old);
+    Object.assign(parser, old);
   }
-}
-
-function peekNextType(parser) {
-  return parser.withLookAhead(1, () => parser.type);
-}
-
-function isExportDefaultSpecifier() {
-  return this.type === tt.name &&
-    this.withLookAhead(1, isCommaOrFrom);
-}
-
-function isCommaOrFrom(parser) {
-  return parser.type === tt.comma ||
-    (parser.type === tt.name &&
-     parser.value === "from");
-}
-
-function parseExportSpecifiersMaybe(node) {
-  if (this.eat(tt.comma)) {
-    node.specifiers.push.apply(
-      node.specifiers,
-      this.parseExportSpecifiers()
-    );
-  }
-}
-
-function parseExportFrom(node, exports) {
-  const hasFrom = this.eatContextual("from") && this.type === tt.string;
-  node.source = hasFrom ? this.parseExprAtom() : null;
-
-  if (node.specifiers) {
-    for (let i = 0; i < node.specifiers.length; i++) {
-      const s = node.specifiers[i];
-      const exported = s.exported;
-      exports[exported.name] = true;
-    }
-  }
-
-  this.semicolon();
-}
-
-function shouldParseExportDeclaration() {
-  return this.type.keyword === "var" ||
-    this.type.keyword === "const" ||
-    this.type.keyword === "class" ||
-    this.type.keyword === "function" ||
-    this.isLet() ||
-    this.isAsyncFunction();
 }

--- a/lib/parsers/acorn.js
+++ b/lib/parsers/acorn.js
@@ -1,29 +1,19 @@
 "use strict";
 
-let acorn = null;
-let acornExtensions = null;
+const acorn = require("acorn");
+const acornExtensions = require("./acorn-extensions.js");
 
 exports.options = {
   ecmaVersion: 8,
   sourceType: "module",
+  allowHashBang: true,
   allowImportExportEverywhere: true,
-  allowReturnOutsideFunction: true,
-  allowHashBang: true
+  allowReturnOutsideFunction: true
 };
 
 function acornParse(code) {
-  if (acorn === null) {
-    acorn = require("acorn");
-  }
-
-  if (acornExtensions === null) {
-    acornExtensions = require("./acorn-extensions.js");
-  }
-
   const parser = new acorn.Parser(exports.options, code);
-
   acornExtensions.enableAll(parser);
-
   return parser.parse();
 }
 

--- a/lib/parsers/top-level.js
+++ b/lib/parsers/top-level.js
@@ -1,46 +1,40 @@
 "use strict";
 
-let acorn = null;
-let acornExtensions = null;
+const acorn = require("acorn");
+const acornExtensions = require("./acorn-extensions.js");
 
 exports.options = {
   ecmaVersion: 8,
   sourceType: "module",
+  allowHashBang: true,
   allowImportExportEverywhere: true,
-  allowReturnOutsideFunction: true,
-  allowHashBang: true
+  allowReturnOutsideFunction: true
 };
 
-// Inspired by https://github.com/RReverser/esmod/blob/master/index.js:
+// Inspired by esmod's acorn parseBlock modification.
+// Copyright Ingvar Stepanyan. Released under MIT license:
+// https://github.com/RReverser/esmod/blob/master/index.js
+
 function quickParseBlock() {
   const node = this.startNode();
-  const length = this.context.length;
-
-  do this.next();
-  while (this.context.length >= length);
-  this.next();
+  const prevPos = this.context.length - 1;
 
   node.body = [];
 
+  do {
+    this.next();
+  } while (this.context.length > prevPos);
+
+  this.next();
   return this.finishNode(node, "BlockStatement");
 }
 
 function topLevelParse(code) {
-  if (acorn === null) {
-    acorn = require("acorn");
-  }
-
-  if (acornExtensions === null) {
-    acornExtensions = require("./acorn-extensions.js");
-  }
-
   const parser = new acorn.Parser(exports.options, code);
-
   acornExtensions.enableAll(parser);
 
   // Override the Parser's parseBlock method.
   parser.parseBlock = quickParseBlock;
-
   return parser.parse();
 }
 

--- a/test/output-tests.js
+++ b/test/output-tests.js
@@ -28,8 +28,8 @@ Object.keys(files).forEach((absPath) => {
 describe("output", () => {
   function check(data) {
     const code = compile(data.actual).code;
-    // Trim blank lines and trailing whitespace.
-    const actual = code.replace(/^ +$/gm, "").trimRight();
+    // Consolidate semicolons then trim blank lines and trailing whitespace.
+    const actual = code.replace(/;{2,}/g, ";").replace(/^ +$/gm, "").trimRight();
     const expected = data.expected.trimRight();
 
     assert.strictEqual(actual, expected);

--- a/test/output/anon-class/expected.js
+++ b/test/output/anon-class/expected.js
@@ -2,4 +2,4 @@
   constructor(value) {
     this.value = value;
   }
-}));;
+}));


### PR DESCRIPTION
This PR cleans up the acorn-extensions.

* Removed unneeded lazy loading logic of `acorn` and `acorn-extensions`
* Removes duplicated functionality that's already provided by acorn
* Overwrites `parser.checkExports` to remove checks which removes checks from `parseExportSpecifiers` (which means our lack of checks is consistent 😃 )
* It removes a rogue trailing semicolon from exported functions/classes (I should patch acorn/babylon)
* It avoids extending the parser with non-standard methods (keeps them helpers instead)
* It splits out the massive `parseExport` into more manageable chunks.