### PR TITLE
Align arrow function options with let declaration option naming.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -25,8 +25,8 @@ module.exports = class ImportExportVisitor extends Visitor {
       }
 
       const namedExports = toModuleExport(
-        bodyInfo.hoistedExportsMap,
-        this.avoidArrowFunctions
+        this,
+        bodyInfo.hoistedExportsMap
       );
 
       if (namedExports) {
@@ -97,8 +97,8 @@ module.exports = class ImportExportVisitor extends Visitor {
     this.bodyInfos = [];
     this.enforceStrictMode = getOption(options, "enforceStrictMode");
     this.exportedLocalNames = Object.create(null);
+    this.generateArrowFunctions = !! getOption(options, "generateArrowFunctions");
     this.generateLetDeclarations = !! getOption(options, "generateLetDeclarations");
-    this.avoidArrowFunctions = !! getOption(options, "avoidArrowFunctions");
     this.madeChanges = false;
     this.modifyAST = !! getOption(options, "ast");
     this.nextKey = 0;
@@ -773,7 +773,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
   return code;
 }
 
-function toModuleExport(specifierMap, avoidArrowFunctions) {
+function toModuleExport(visitor, specifierMap) {
   let code = "";
   const exportedKeys = Object.keys(specifierMap);
   const keyCount = exportedKeys.length;
@@ -794,10 +794,10 @@ function toModuleExport(specifierMap, avoidArrowFunctions) {
 
     code += exported + ":";
 
-    if (avoidArrowFunctions) {
-      code += "function(){return " + locals[0] + "}";
-    } else {
+    if (visitor.generateArrowFunctions) {
       code += "()=>" + locals[0];
+    } else {
+      code += "function(){return " + locals[0] + "}";
     }
 
     if (! isLast) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -8,8 +8,8 @@ const defaultOptions = {
   // one import or export declaration.
   enforceStrictMode: true,
   force: false,
+  generateArrowFunctions: true,
   generateLetDeclarations: false,
-  avoidArrowFunctions: false,
   get parse () {
     return require("./parsers/default.js").parse;
   }

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -40,6 +40,19 @@ describe("compiler", () => {
     assert.strictEqual(check(), true);
   });
 
+  it("should respect options.generateArrowFunctions", () => {
+    import { compile } from "../lib/compiler.js";
+
+    const compiled = compile([
+      'import def from "mod"',
+      "export { def as x }"
+    ].join("\n"), {
+      generateArrowFunctions: false
+    }).code;
+
+    assert.ok(! compiled.includes("=>"));
+  });
+
   it("should respect options.generateLetDeclarations", () => {
     import { compile } from "../lib/compiler.js";
 
@@ -60,19 +73,6 @@ describe("compiler", () => {
     assert.ok(compile(
       'import foo from "./foo"'
     ).code.startsWith('"use strict";var foo;'));
-  });
-
-  it("should respect options.avoidArrowFunctions", () => {
-    import { compile } from "../lib/compiler.js";
-
-    const compiled = compile([
-      'import def from "mod"',
-      'export { def as x }'
-    ].join("\n"), {
-      avoidArrowFunctions: true
-    }).code;
-
-    assert.strictEqual(compiled.indexOf("=>"), -1);
   });
 
   it("should allow pre-parsed ASTs via options.parse", () => {


### PR DESCRIPTION
This also passes the visitor to `toModuleExport` which allows for other options to be used without expanding the argument signature.