### PR TITLE
Rename `force` option to `sourceType`.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -24,11 +24,13 @@ const shebangRegExp = /^#!.*/;
 exports.compile = function (code, options) {
   options = Object.assign(Object.create(null), options);
 
+  const parse = getOption(options, "parse");
+  const sourceType = getOption(options, "sourceType");
+
   if (code.charCodeAt(0) === poundCode) {
     code = code.replace(shebangRegExp, "");
   }
 
-  const parse = getOption(options, "parse");
   const ast = parse(code);
 
   const result = {
@@ -41,8 +43,8 @@ exports.compile = function (code, options) {
     result.ast = ast;
   }
 
-  if (! getOption(options, "force") &&
-      ! importExportRegExp.test(code)) {
+  if (sourceType === "script" ||
+      (sourceType === "unambiguous" && ! importExportRegExp.test(code))) {
     // Let the caller know the result is no different from the input.
     result.identical = true;
     return result;
@@ -55,7 +57,7 @@ exports.compile = function (code, options) {
 
   const magicString = importExportVisitor.magicString;
 
-  if (! result.identical) {
+  if (! result.identical || sourceType === "module") {
     assignmentVisitor.visit(rootPath, {
       exportedLocalNames: importExportVisitor.exportedLocalNames,
       magicString: magicString,

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -13,14 +13,17 @@ const exportDefaultSuffix = "));";
 module.exports = class ImportExportVisitor extends Visitor {
   finalizeHoisting() {
     const infoCount = this.bodyInfos.length;
+    const isModule = this.sourceType === "module";
 
     for (let i = 0; i < infoCount; ++i) {
       const bodyInfo = this.bodyInfos[i];
       let codeToInsert = "";
 
       // We don't need to add a "use strict" directive unless the compiler
-      // made any changes.
-      if (this.madeChanges && bodyInfo.needToAddUseStrictDirective) {
+      // made changes or the sourceType is "module".
+      if (bodyInfo.needToAddUseStrictDirective &&
+          (this.madeChanges || isModule)) {
+        this.madeChanges = true;
         codeToInsert += '"use strict";';
       }
 
@@ -104,6 +107,7 @@ module.exports = class ImportExportVisitor extends Visitor {
     this.nextKey = 0;
     this.parse = getOption(options, "parse");
     this.removals = [];
+    this.sourceType = getOption(options, "sourceType");
   }
 
   visitProgram(path) {
@@ -494,12 +498,8 @@ function getBlockBodyInfo(visitor, path) {
     parent._bodyInfoByName || Object.create(null);
 
   let bodyInfo = bibn[bodyName];
-  if (bodyInfo) {
-    assert.strictEqual(bodyInfo.body, body);
-
-  } else {
+  if (bodyInfo === void 0) {
     bodyInfo = bibn[bodyName] = Object.create(null);
-
     bodyInfo.body = body;
     bodyInfo.parent = parent;
     bodyInfo.insertCharIndex = insertCharIndex;
@@ -509,11 +509,14 @@ function getBlockBodyInfo(visitor, path) {
     bodyInfo.hoistedImportsString = "";
 
     visitor.bodyInfos.push(bodyInfo);
+
+  } else {
+    assert.strictEqual(bodyInfo.body, body);
   }
 
-  bodyInfo.needToAddUseStrictDirective =
-    needToAddUseStrictDirective ||
-    bodyInfo.needToAddUseStrictDirective;
+  if (needToAddUseStrictDirective) {
+    bodyInfo.needToAddUseStrictDirective = needToAddUseStrictDirective;
+  }
 
   return bodyInfo;
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,9 +7,9 @@ const defaultOptions = {
   // If not false, "use strict" will be added to any modules with at least
   // one import or export declaration.
   enforceStrictMode: true,
-  force: false,
   generateArrowFunctions: true,
   generateLetDeclarations: false,
+  sourceType: "unambiguous",
   get parse () {
     return require("./parsers/default.js").parse;
   }

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -64,16 +64,20 @@ function compileWithCache(pkgInfo, content, options) {
     return cacheValue;
   }
 
+  const compileOptions = {
+    parse: void 0,
+    sourceType: void 0
+  };
+
   const filename = options.filename;
   const hasFilename = typeof filename === "string";
 
-  const compileOptions = {
-    force: hasFilename && path.extname(filename) === ".mjs",
-    parse: void 0
-  };
-
   if (typeof pkgCfg.parser === "string") {
     compileOptions.parse = dynRequire(pkgCfg.parser).parse;
+  }
+
+  if (hasFilename && path.extname(filename) === ".mjs") {
+    compileOptions.sourceType = "module";
   }
 
   const result = compile(content, compileOptions);


### PR DESCRIPTION
This renames the `force` option to `sourceType` which aligns [with babel/babylon](https://github.com/babel/babylon/pull/449).