### PR TITLE
Implement Module.isESModuleExports.

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -56,7 +56,7 @@ exports.enable = function (Module) {
   // inside loops. The compiler generates these keys automatically (and
   // deterministically) when compiling nested import declarations.
   Mp.importSync = function (id, setters, key) {
-    setESModule(this);
+    setESModule(this.exports);
 
     var absoluteId = this.resolve(id);
 
@@ -88,7 +88,7 @@ exports.enable = function (Module) {
   // export statement. The keys of the getters object are exported names,
   // and the values are functions that return local values.
   Mp.export = function (getters) {
-    setESModule(this);
+    setESModule(this.exports);
 
     if (typeof getters === "object" && getters !== null) {
       Entry.getOrCreate(this.id).addGetters(getters);
@@ -113,10 +113,7 @@ exports.enable = function (Module) {
     }
 
     if (name === "default" &&
-        ! (typeof exports === "object" && exports !== null &&
-           (hasOwn.call(exports, "__esModule") ||
-             (__esSymbol && hasOwn.call(exports, __esSymbol))) &&
-           "default" in exports)) {
+        ! (getESModule(exports) && "default" in exports)) {
       return exports;
     }
 
@@ -127,15 +124,29 @@ exports.enable = function (Module) {
     return exports[name];
   };
 
+  // Utility for determining if a given module.exports was produced by an
+  // ECMAScript module.
+  Module.isESModuleExports = getESModule;
+
   return Module;
 };
 
-function setESModule(module) {
-  var exports = module.exports;
-  if (typeof exports === "object" && exports !== null &&
-      ! hasOwn.call(exports, "__esModule") &&
-      ! (__esSymbol && hasOwn.call(exports, __esSymbol))) {
+function getESModule(exports) {
+  if (typeof exports === "object" && exports !== null) {
+    if (__esSymbol && hasOwn.call(exports, __esSymbol)) {
+      return !! exports[__esSymbol];
+    }
 
+    if (hasOwn.call(exports, "__esModule")) {
+      return !! exports.__esModule;
+    }
+  }
+
+  return false;
+}
+
+function setESModule(exports) {
+  if (! getESModule(exports)) {
     if (__esSymbol) {
       exports[__esSymbol] = true;
     } else {
@@ -146,6 +157,5 @@ function setESModule(module) {
         configurable: true
       });
     }
-
   }
 }


### PR DESCRIPTION
It was tempting to implement `Module.prototype.isESModule`, but it's also important to be able to determine if the `exports` object returned by a child module has a truthy `"__esModule"` or `__esSymbol` property, even if we don't have direct access to the child module's `module` object.