### PR TITLE
Use module.exports objects as setter/getter coordination points

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -7,14 +7,12 @@ var GETTER_ERROR = {};
 var NAN = {};
 var UNDEFINED = {};
 var hasOwn = UNDEFINED.hasOwnProperty;
-
-var entryMap = new FastObject;
 var keySalt = 0;
 
-function Entry(id) {
-  // Same as module.id for this module.
-  this.id = id;
-  // The number of times this.runModuleSetters has been called.
+function Entry(exports) {
+  // The module.exports of the module this Entry is managing.
+  this.exports = exports;
+  // The number of times this.runSetters has been called.
   this.runCount = 0;
   // Setters for assigning to local variables in parent modules.
   this.setters = new FastObject;
@@ -24,15 +22,43 @@ function Entry(id) {
 
 var Ep = Entry.prototype;
 
-Entry.get = function (id) {
-  return id in entryMap ? entryMap[id] : null;
+var entryKey = typeof Symbol === "function"
+  ? Symbol.for("reifyEntry")
+  : makeUniqueKey();
+
+Entry.get = function (exports) {
+  if (utils.isObject(exports) &&
+      hasOwn.call(exports, entryKey)) {
+    return exports[entryKey];
+  }
+  return null;
 };
 
-Entry.getOrCreate = function (id) {
-  if (id in entryMap) {
-    return entryMap[id];
+Entry.getOrCreate = function (exports) {
+  if (utils.isObject(exports)) {
+    if (hasOwn.call(exports, entryKey)) {
+      return exports[entryKey];
+    }
+
+    var entry = new Entry(exports);
+
+    if (typeof entryKey === "symbol") {
+      exports[entryKey] = entry;
+    } else {
+      Object.defineProperty(exports, entryKey, {
+        value: entry,
+        enumerable: false,
+        writable: false,
+        configurable: true
+      });
+    }
+
+    return entry;
   }
-  return entryMap[id] = new Entry(id);
+
+  // TODO What are the consequences of this hack?
+  // Should it be new Entry({ default: exports })?
+  return new Entry(exports);
 };
 
 Ep.addGetters = function (getters) {
@@ -81,9 +107,11 @@ Ep.addSetters = function (parent, setters, key) {
       this.setters[name][key] = setter;
     }
   }
+
+  this.runSetters(names);
 };
 
-Ep.runModuleGetters = function (module, names) {
+Ep.runGetters = function (names) {
   var needToCheckNames = true;
   if (typeof names === "undefined") {
     names = Object.keys(this.getters);
@@ -106,7 +134,7 @@ Ep.runModuleGetters = function (module, names) {
     // the current value so that CommonJS require calls remain consistent with
     // module.importSync.
     if (value !== GETTER_ERROR) {
-      module.exports[name] = value;
+      this.exports[name] = value;
     }
   }
 };
@@ -114,16 +142,16 @@ Ep.runModuleGetters = function (module, names) {
 // Called whenever module.exports might have changed, to trigger any
 // setters associated with the newly exported values. The names parameter
 // is optional; without it, all getters and setters will run.
-Ep.runModuleSetters = function (module, names) {
+Ep.runSetters = function (names) {
   // Make sure module.exports is up to date before we call
   // getExportByName(module.exports, name).
-  this.runModuleGetters(module, names);
+  this.runGetters(names);
 
   // Lazily-initialized object mapping parent module identifiers to parent
   // module objects whose setters we might need to run.
   var parents;
 
-  forEachSetter(module, this, function (setter, name, value) {
+  forEachSetter(this, function (setter, name, value) {
     if (parents === void 0) {
       parents = Object.create(null);
     }
@@ -149,12 +177,12 @@ Ep.runModuleSetters = function (module, names) {
   for (var i = 0; i < parentIDCount; ++i) {
     // What happens if parents[parentIDs[id]] === module, or if
     // longer cycles exist in the parent chain? Thanks to our setter.last
-    // bookkeeping above, the runModuleSetters broadcast will only proceed
+    // bookkeeping above, the runSetters broadcast will only proceed
     // as far as there are any actual changes to report.
     var parent = parents[parentIDs[i]];
-    var id = parent.id;
-    if (id in entryMap) {
-      entryMap[id].runModuleSetters(parent);
+    var parentEntry = Entry.get(parent.exports);
+    if (parentEntry) {
+      parentEntry.runSetters();
     }
   }
 };
@@ -188,7 +216,7 @@ function call(setter, name, value, callback) {
 // Invoke the given callback once for every (setter, value, name) triple
 // that needs to be called. Note that forEachSetter does not call any
 // setters itself, only the given callback.
-function forEachSetter(module, entry, callback, names) {
+function forEachSetter(entry, callback, names) {
   var needToCheckNames = true;
   if (typeof names === "undefined") {
     names = Object.keys(entry.setters);
@@ -209,7 +237,7 @@ function forEachSetter(module, entry, callback, names) {
 
     for (var j = 0; j < keyCount; ++j) {
       var key = keys[j];
-      var value = getExportByName(module.exports, name);
+      var value = getExportByName(entry.exports, name);
 
       if (name === "*") {
         var valueNames = Object.keys(value);

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var FastObject = require("./utils.js").FastObject;
+var utils = require("./utils.js");
+var FastObject = utils.FastObject;
 
 var GETTER_ERROR = {};
 var NAN = {};
@@ -102,7 +103,7 @@ Ep.runModuleGetters = function (module) {
 // setters associated with the newly exported values.
 Ep.runModuleSetters = function (module) {
   // Make sure module.exports is up to date before we call
-  // module.getExportByName(name).
+  // getExportByName(module.exports, name).
   this.runModuleGetters(module);
 
   // Lazily-initialized object mapping parent module identifiers to parent
@@ -186,7 +187,7 @@ function forEachSetter(module, entry, callback) {
 
     for (var j = 0; j < keyCount; ++j) {
       var key = keys[j];
-      var value = module.getExportByName(name);
+      var value = getExportByName(module.exports, name);
 
       if (name === "*") {
         var valueNames = Object.keys(value);
@@ -202,6 +203,24 @@ function forEachSetter(module, entry, callback) {
       }
     }
   }
+}
+
+function getExportByName(exports, name) {
+  if (name === "*") {
+    return exports;
+  }
+
+  if (name === "default" &&
+      ! (utils.getESModule(exports) &&
+         "default" in exports)) {
+    return exports;
+  }
+
+  if (exports == null) {
+    return;
+  }
+
+  return exports[name];
 }
 
 function makeUniqueKey() {

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -6,6 +6,7 @@ var FastObject = utils.FastObject;
 var GETTER_ERROR = {};
 var NAN = {};
 var UNDEFINED = {};
+var hasOwn = UNDEFINED.hasOwnProperty;
 
 var entryMap = new FastObject;
 var keySalt = 0;
@@ -82,12 +83,23 @@ Ep.addSetters = function (parent, setters, key) {
   }
 };
 
-Ep.runModuleGetters = function (module) {
-  var names = Object.keys(this.getters);
+Ep.runModuleGetters = function (module, names) {
+  var needToCheckNames = true;
+  if (typeof names === "undefined") {
+    names = Object.keys(this.getters);
+    needToCheckNames = false;
+  }
+
   var nameCount = names.length;
 
   for (var i = 0; i < nameCount; ++i) {
     var name = names[i];
+
+    if (needToCheckNames &&
+        ! hasOwn.call(this.getters, name)) {
+      continue;
+    }
+
     var value = runGetter(this, name);
 
     // If the getter is run without error, update module.exports[name] with
@@ -100,11 +112,12 @@ Ep.runModuleGetters = function (module) {
 };
 
 // Called whenever module.exports might have changed, to trigger any
-// setters associated with the newly exported values.
-Ep.runModuleSetters = function (module) {
+// setters associated with the newly exported values. The names parameter
+// is optional; without it, all getters and setters will run.
+Ep.runModuleSetters = function (module, names) {
   // Make sure module.exports is up to date before we call
   // getExportByName(module.exports, name).
-  this.runModuleGetters(module);
+  this.runModuleGetters(module, names);
 
   // Lazily-initialized object mapping parent module identifiers to parent
   // module objects whose setters we might need to run.
@@ -119,7 +132,7 @@ Ep.runModuleSetters = function (module) {
     // The param order for setters is `value` then `name` because the `name`
     // param is only used by namespace exports.
     setter(value, name);
-  });
+  }, names);
 
   ++this.runCount;
 
@@ -175,12 +188,21 @@ function call(setter, name, value, callback) {
 // Invoke the given callback once for every (setter, value, name) triple
 // that needs to be called. Note that forEachSetter does not call any
 // setters itself, only the given callback.
-function forEachSetter(module, entry, callback) {
-  var names = Object.keys(entry.setters);
+function forEachSetter(module, entry, callback, names) {
+  var needToCheckNames = true;
+  if (typeof names === "undefined") {
+    names = Object.keys(entry.setters);
+    needToCheckNames = false;
+  }
   var nameCount = names.length;
 
   for (var i = 0; i < nameCount; ++i) {
     var name = names[i];
+    if (needToCheckNames &&
+        ! hasOwn.call(entry.setters, name)) {
+      continue;
+    }
+
     var setters = entry.setters[name];
     var keys = Object.keys(setters);
     var keyCount = keys.length;

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -4,6 +4,7 @@
 // Recast: https://github.com/benjamn/recast/blob/master/lib/fast-path.js
 
 const assert = require("assert");
+const utils = require("./utils.js");
 
 const codeOfA = "A".charCodeAt(0);
 const codeOfZ = "Z".charCodeAt(0);
@@ -144,7 +145,8 @@ function isCapitalized(string) {
 // maintaining a complete list of type names is one of the reasons we're
 // using the FastPath/Visitor abstraction in the first place.
 function isNodeLike(value) {
-  return typeof value === "object" && value !== null &&
-    ! Array.isArray(value) && isCapitalized(value.type);
+  return utils.isObject(value) &&
+    ! Array.isArray(value) &&
+    isCapitalized(value.type);
 }
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,8 +1,7 @@
 "use strict";
 
-var __esSymbol = typeof Symbol === "function" ? Symbol.for("__esModule") : null;
-var hasOwn = Object.prototype.hasOwnProperty;
 var Entry = require("./entry.js");
+var utils = require("./utils.js");
 
 exports.enable = function (Module) {
   var Mp = Module.prototype;
@@ -56,7 +55,7 @@ exports.enable = function (Module) {
   // inside loops. The compiler generates these keys automatically (and
   // deterministically) when compiling nested import declarations.
   Mp.importSync = function (id, setters, key) {
-    setESModule(this);
+    utils.setESModule(this.exports);
 
     var absoluteId = this.resolve(id);
 
@@ -88,7 +87,7 @@ exports.enable = function (Module) {
   // export statement. The keys of the getters object are exported names,
   // and the values are functions that return local values.
   Mp.export = function (getters) {
-    setESModule(this);
+    utils.setESModule(this.exports);
 
     if (typeof getters === "object" && getters !== null) {
       Entry.getOrCreate(this.id).addGetters(getters);
@@ -113,9 +112,7 @@ exports.enable = function (Module) {
     }
 
     if (name === "default" &&
-        ! (typeof exports === "object" && exports !== null &&
-           (hasOwn.call(exports, "__esModule") ||
-             (__esSymbol && hasOwn.call(exports, __esSymbol))) &&
+        ! (utils.getESModule(exports) &&
            "default" in exports)) {
       return exports;
     }
@@ -129,23 +126,3 @@ exports.enable = function (Module) {
 
   return Module;
 };
-
-function setESModule(module) {
-  var exports = module.exports;
-  if (typeof exports === "object" && exports !== null &&
-      ! hasOwn.call(exports, "__esModule") &&
-      ! (__esSymbol && hasOwn.call(exports, __esSymbol))) {
-
-    if (__esSymbol) {
-      exports[__esSymbol] = true;
-    } else {
-      Object.defineProperty(exports, "__esModule", {
-        value: true,
-        enumerable: false,
-        writable: false,
-        configurable: true
-      });
-    }
-
-  }
-}

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -65,21 +65,12 @@ exports.enable = function (Module) {
     }
 
     var entry = Entry.getOrCreate(absoluteId);
-    entry.addSetters(this, setters, key);
-
-    var countBefore = entry.runCount;
     var exports = this.require(absoluteId);
 
-    if (entry.runCount === countBefore) {
-      // If require(absoluteId) didn't run any setters for this entry,
-      // perhaps because it's not the first time this module has been
-      // required, run the setters now using an object that passes as the
-      // real module object.
-      entry.runModuleSetters({
-        id: absoluteId,
-        exports: exports
-      });
-    }
+    entry.addSetters(this, setters, key);
+    entry.runModuleSetters({
+      exports: exports
+    }, Object.keys(setters));
   };
 
   // Register getter functions for local variables in the scope of an

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -13,21 +13,14 @@ exports.enable = function (Module) {
     return Module;
   }
 
-  // Platform-specific code should implement this method however
-  // appropriate. Module.prototype.resolve(id) should return an absolute
-  // version of the given module identifier, like require.resolve.
-  Mp.resolve = Mp.resolve || function resolve(id) {
-    throw new Error("Module.prototype.resolve not implemented");
-  };
-
   // Platform-specific code should find a way to call this method whenever
   // the module system is about to return module.exports from require. This
   // might happen more than once per module, in case of dependency cycles,
   // so we want Module.prototype.runModuleSetters to run each time.
   Mp.runModuleSetters = function runModuleSetters(valueToPassThrough) {
-    var entry = Entry.get(this.id);
+    var entry = Entry.get(this.exports);
     if (entry !== null) {
-      entry.runModuleSetters(this);
+      entry.runSetters();
     }
 
     // Assignments to exported local variables get wrapped with calls to
@@ -56,21 +49,10 @@ exports.enable = function (Module) {
   // deterministically) when compiling nested import declarations.
   Mp.importSync = function (id, setters, key) {
     utils.setESModule(this.exports);
-
-    var absoluteId = this.resolve(id);
-
-    if (! utils.isObject(setters)) {
-      this.require(absoluteId);
-      return;
+    var exports = this.require(id);
+    if (utils.isObject(setters)) {
+      Entry.getOrCreate(exports).addSetters(this, setters, key);
     }
-
-    var entry = Entry.getOrCreate(absoluteId);
-    var exports = this.require(absoluteId);
-
-    entry.addSetters(this, setters, key);
-    entry.runModuleSetters({
-      exports: exports
-    }, Object.keys(setters));
   };
 
   // Register getter functions for local variables in the scope of an
@@ -78,16 +60,17 @@ exports.enable = function (Module) {
   // and the values are functions that return local values.
   Mp.export = function (getters) {
     utils.setESModule(this.exports);
+    var entry = Entry.getOrCreate(this.exports);
 
     if (utils.isObject(getters)) {
-      Entry.getOrCreate(this.id).addGetters(getters);
+      entry.addGetters(getters);
     }
 
     if (this.loaded) {
       // If the module has already been evaluated, then we need to trigger
       // another round of entry.runModuleSetters calls, which begins by
       // calling entry.runModuleGetters(module).
-      this.runModuleSetters();
+      entry.runSetters();
     }
   };
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -59,7 +59,7 @@ exports.enable = function (Module) {
 
     var absoluteId = this.resolve(id);
 
-    if (! (typeof setters === "object" && setters !== null)) {
+    if (! utils.isObject(setters)) {
       this.require(absoluteId);
       return;
     }
@@ -89,7 +89,7 @@ exports.enable = function (Module) {
   Mp.export = function (getters) {
     utils.setESModule(this.exports);
 
-    if (typeof getters === "object" && getters !== null) {
+    if (utils.isObject(getters)) {
       Entry.getOrCreate(this.id).addGetters(getters);
     }
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -77,8 +77,7 @@ exports.enable = function (Module) {
       // real module object.
       entry.runModuleSetters({
         id: absoluteId,
-        exports: exports,
-        getExportByName: Mp.getExportByName
+        exports: exports
       });
     }
   };
@@ -99,29 +98,6 @@ exports.enable = function (Module) {
       // calling entry.runModuleGetters(module).
       this.runModuleSetters();
     }
-  };
-
-  // This method can be overridden by client code to implement custom export
-  // naming logic. The current implementation works well with Babel's
-  // __esModule convention.
-  Mp.getExportByName = function (name) {
-    var exports = this.exports;
-
-    if (name === "*") {
-      return exports;
-    }
-
-    if (name === "default" &&
-        ! (utils.getESModule(exports) &&
-           "default" in exports)) {
-      return exports;
-    }
-
-    if (exports == null) {
-      return;
-    }
-
-    return exports[name];
   };
 
   return Module;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,6 +29,7 @@ exports.FastObject = FastObject;
 function isObject(value) {
   return typeof value === "object" && value !== null;
 }
+exports.isObject = isObject;
 
 // This version assumes exports is an object.
 function getESModule(exports) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 "use strict";
 
+var hasOwn = Object.prototype.hasOwnProperty;
 var fastProto = null;
+var __esSymbol = typeof Symbol === "function" ? Symbol.for("__esModule") : null;
 
 // Creates an object with permanently fast properties in V8. See Toon Verwaest's
 // post https://medium.com/@tverwaes/setting-up-prototypes-in-v8-ec9c9491dfe2#5f62
@@ -23,6 +25,42 @@ function FastObject() {
 FastObject();
 
 exports.FastObject = FastObject;
+
+function isObject(value) {
+  return typeof value === "object" && value !== null;
+}
+
+// This version assumes exports is an object.
+function getESModule(exports) {
+  if (hasOwn.call(exports, "__esModule")) {
+    return !! exports.__esModule;
+  }
+
+  if (__esSymbol && hasOwn.call(exports, __esSymbol)) {
+    return !! exports[__esSymbol];
+  }
+
+  return false;
+}
+
+exports.getESModule = function (exports) {
+  return isObject(exports) && getESModule(exports);
+};
+
+exports.setESModule = function (exports) {
+  if (isObject(exports) && ! getESModule(exports)) {
+    if (__esSymbol) {
+      exports[__esSymbol] = true;
+    } else {
+      Object.defineProperty(exports, "__esModule", {
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: true
+      });
+    }
+  }
+};
 
 function getNamesFromPattern(pattern) {
   var queue = [pattern];

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const underscoreCode = "_".charCodeAt(0);
+const utils = require("./utils.js");
 
 // This Visitor API was inspired by a similar API provided by ast-types:
 // https://github.com/benjamn/ast-types/blob/master/lib/path-visitor.js
@@ -65,7 +66,7 @@ module.exports = class Visitor {
       }
 
       const value = node[key];
-      if (! (typeof value === "object" && value !== null)) {
+      if (! utils.isObject(value)) {
         // Ignore properties whose values aren't objects.
         continue;
       }


### PR DESCRIPTION
This refactoring has several big consequences:
1. `Module.prototype` no longer needs to have a working `.resolve` method.
2. CommonJS bridge modules that set `module.exports = require(...)` will now preserve live bindings, since the `exports` object is what matters.
3. The global `entryMap` object is gone, which should make it easier for different versions of Reify to interact (#152), and may prevent memory leaks (thought `require.cache` probably keeps everything alive anyway).
4. It may now be possible to hoist the `require` call out of `module.importSync`, so that it can be understood by generic CommonJS bundlers.