### PR TITLE
Make require.extensions wrapper logic more defensive

### DIFF
--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -6,7 +6,7 @@ const path = require("path");
 const runtime = require("../lib/runtime.js");
 const utils = require("./utils.js");
 const wrappers = require("./wrappers.js");
-const createWrapperManager = wrappers.createWrapperManager;
+const ensureWrapperMap = wrappers.ensureWrapperMap;
 const addWrapper = wrappers.addWrapper;
 
 const Module = require("module");
@@ -23,9 +23,9 @@ module.exports = exports = (options) => {
   }
 };
 
-createWrapperManager(exts, ".js");
+const jsWrapperMap = ensureWrapperMap(exts, ".js");
 
-addWrapper(exts[".js"], function(func, pkgInfo, module, filename) {
+addWrapper(exts, ".js", function(func, pkgInfo, module, filename) {
   const cachePath = pkgInfo.cachePath;
   if (cachePath === null) {
     return func.call(this, module, filename);
@@ -70,10 +70,10 @@ addWrapper(exts[".js"], function(func, pkgInfo, module, filename) {
   if (typeof exts[key] !== "function") {
     // Mimic the built-in Node behavior of treating files with unrecognized
     // extensions as .js.
-    exts[key] = exts[".js"].reified.raw;
+    exts[key] = jsWrapperMap.raw;
   }
-  createWrapperManager(exts, key);
-  addWrapper(exts[key], function(func, module, filename) {
-    exts[".js"].reified.wrappers[reifyVersion].call(this, module, filename);
+
+  addWrapper(exts, key, function(func, module, filename) {
+    jsWrapperMap.wrappers[reifyVersion].call(this, module, filename);
   });
 });

--- a/node/wrappers.js
+++ b/node/wrappers.js
@@ -7,34 +7,60 @@ const isObject = require("../lib/utils.js").isObject;
 const utils = require("./utils.js");
 const reifySemVer = utils.getReifySemVer();
 const reifyVersion = reifySemVer.version;
+const hasOwn = Object.prototype.hasOwnProperty;
 
-function addWrapper(func, wrapper) {
-  const reified = func.reified;
-  if (typeof reified.wrappers[reifyVersion] !== "function") {
-    reified.versions.push(reifyVersion);
-    reified.wrappers[reifyVersion] = wrapper;
+function getSymbolForKey(key) {
+  return Symbol.for("reifyWrapperMap$" + key);
+}
+
+function addWrapper(object, key, wrapper) {
+  const map = ensureWrapperMap(object, key);
+  if (typeof map.wrappers[reifyVersion] !== "function") {
+    map.versions.push(reifyVersion);
+    map.wrappers[reifyVersion] = wrapper;
   }
 }
 
 exports.addWrapper = addWrapper;
 
-function createWrapperManager(object, key) {
-  const func = object[key];
-  if (! isManaged(func)) {
-    (object[key] = function wrapperFunc(param, filename) {
+function ensureWrapperMap(object, key) {
+  let map = getWrapperMap(object, key);
+  if (map === null) {
+    const func = object[key];
+    map = createWrapperMap(func);
+
+    object[key] = function (param, filename) {
       const pkgInfo = utils.getPkgInfo(path.dirname(filename));
       const wrapper = pkgInfo === null ? null :
-        findWrapper(wrapperFunc, pkgInfo.range);
+        findWrapper(object, key, pkgInfo.range);
 
       // A wrapper should only be null for reify < 0.10.
       return wrapper === null
         ? func.call(this, param, filename)
         : wrapper.call(this, func, pkgInfo, param, filename);
-    }).reified = createWrapperMap(func);
+    };
+
+    // Store the wrapper map on the object rather than on the function so
+    // that other code can modify the same property without interfering
+    // with our wrapper logic.
+    object[getSymbolForKey(key)] = map;
   }
+
+  return map;
 }
 
-exports.createWrapperManager = createWrapperManager;
+exports.ensureWrapperMap = ensureWrapperMap;
+
+function getWrapperMap(object, key) {
+  const symbol = getSymbolForKey(key);
+  if (hasOwn.call(object, symbol)) {
+    const map = object[symbol];
+    if (isObject(map)) {
+      return map;
+    }
+  }
+  return null;
+}
 
 function createWrapperMap(func) {
   const map = new FastObject;
@@ -44,12 +70,13 @@ function createWrapperMap(func) {
   return map;
 }
 
-function findWrapper(func, range) {
-  const reified = func.reified;
-  const version = SemVer.maxSatisfying(reified.versions, range);
-  return version === null ? null : reified.wrappers[version];
-}
-
-function isManaged(func) {
-  return typeof func === "function" && isObject(func.reified);
+function findWrapper(object, key, range) {
+  const map = getWrapperMap(object, key);
+  if (map !== null) {
+    const version = SemVer.maxSatisfying(map.versions, range);
+    if (version !== null) {
+      return map.wrappers[version];
+    }
+  }
+  return null;
 }

--- a/node/wrappers.js
+++ b/node/wrappers.js
@@ -21,9 +21,10 @@ exports.addWrapper = addWrapper;
 function createWrapperManager(object, key) {
   const func = object[key];
   if (! isManaged(func)) {
-    (object[key] = function(param, filename) {
+    (object[key] = function wrapperFunc(param, filename) {
       const pkgInfo = utils.getPkgInfo(path.dirname(filename));
-      const wrapper = pkgInfo === null ? null : findWrapper(object[key], pkgInfo.range);
+      const wrapper = pkgInfo === null ? null :
+        findWrapper(wrapperFunc, pkgInfo.range);
 
       // A wrapper should only be null for reify < 0.10.
       return wrapper === null

--- a/node/wrappers.js
+++ b/node/wrappers.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const path = require("path");
+const SemVer = require("semver");
+const FastObject = require("../lib/fast-object.js");
+const isObject = require("../lib/utils.js").isObject;
+const utils = require("./utils.js");
+const reifySemVer = utils.getReifySemVer();
+const reifyVersion = reifySemVer.version;
+
+function addWrapper(func, wrapper) {
+  const reified = func.reified;
+  if (typeof reified.wrappers[reifyVersion] !== "function") {
+    reified.versions.push(reifyVersion);
+    reified.wrappers[reifyVersion] = wrapper;
+  }
+}
+
+exports.addWrapper = addWrapper;
+
+function createWrapperManager(object, key) {
+  const func = object[key];
+  if (! isManaged(func)) {
+    (object[key] = function(param, filename) {
+      const pkgInfo = utils.getPkgInfo(path.dirname(filename));
+      const wrapper = pkgInfo === null ? null : findWrapper(object[key], pkgInfo.range);
+
+      // A wrapper should only be null for reify < 0.10.
+      return wrapper === null
+        ? func.call(this, param, filename)
+        : wrapper.call(this, func, pkgInfo, param, filename);
+    }).reified = createWrapperMap(func);
+  }
+}
+
+exports.createWrapperManager = createWrapperManager;
+
+function createWrapperMap(func) {
+  const map = new FastObject;
+  map.raw = func;
+  map.versions = [];
+  map.wrappers = new FastObject;
+  return map;
+}
+
+function findWrapper(func, range) {
+  const reified = func.reified;
+  const version = SemVer.maxSatisfying(reified.versions, range);
+  return version === null ? null : reified.wrappers[version];
+}
+
+function isManaged(func) {
+  return typeof func === "function" && isObject(func.reified);
+}


### PR DESCRIPTION
Other libraries sometimes modify `require.extensions` to do their own compilation, so I think we should be as tolerant as we can of that.

In [`meteor-babel/register`](https://github.com/meteor/babel/blob/eb32b0907369bfab64ab649b7af1dbb719746dff/register.js#L36-L50) I noticed I had to copy the `.reified` property when I wrapped Reify's `require.extensions[".js"]` function: https://github.com/meteor/babel/commit/eb32b0907369bfab64ab649b7af1dbb719746dff

That seems like too much to ask of libraries that don't know about Reify. The most we can expect is for the other library to call the replaced function, like so:
```js
var defaultHandler = require.extensions[".js"];
require.extensions[".js"] = function(module, filename) {
  if (shouldNotTransform(filename)) {
    defaultHandler(module, filename);
  } else {
    module._compile(
      getBabelResult(filename).code,
      filename
    );
  }
};
```
I believe the most recent commit in this PR fixes this problem by using `wrapperFunc.reified` instead of `object[key].reified`, since `object[key]` might have changed, but I wanted to check with you (@jdalton) that this change seems safe.