### PR TITLE
Use module.watch(require(id), ...) to avoid calling module.require.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -183,16 +183,18 @@ class ImportExportVisitor extends Visitor {
 
   visitExportAllDeclaration(path) {
     const decl = path.getValue();
-    const hoistedCode =
-      pad(this, "module.importSync(", decl.start, decl.source.start) +
-      getSourceString(this, decl) +
-      pad(
-        this,
-        ',{"*":function(v,k){exports[k]=v}},' +
-          makeUniqueKey(this) + ");",
-        decl.source.end,
-        decl.end
-      );
+    const hoistedCode = pad(
+      this,
+      "module.watch(require(" + getSourceString(this, decl) + ")",
+      decl.start,
+      decl.source.start
+    ) + pad(
+      this,
+      ',{"*":function(v,k){exports[k]=v}},' +
+        makeUniqueKey(this) + ");",
+      decl.source.end,
+      decl.end
+    );
 
     hoistExports(this, path, hoistedCode);
   }
@@ -726,7 +728,7 @@ function safeParam(param, locals) {
 }
 
 function toModuleImport(source, specifierMap, uniqueKey) {
-  let code = "module.importSync(" + source;
+  let code = "module.watch(require(" + source + ")";
   const importedNames = Object.keys(specifierMap);
   const nameCount = importedNames.length;
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -11,6 +11,7 @@ exports.enable = function (mod) {
       typeof mod.importSync !== "function") {
     mod.export = moduleExport;
     mod.importSync = importSync;
+    mod.watch = moduleWatch;
     mod.runModuleSetters = runModuleSetters;
     return true;
   }
@@ -18,18 +19,20 @@ exports.enable = function (mod) {
   return false;
 };
 
+function moduleWatch(exported, setters, key) {
+  utils.setESModule(this.exports);
+  if (utils.isObject(setters)) {
+    Entry.getOrCreate(exported).addSetters(this, setters, key);
+  }
+}
+
 // If key is provided, it will be used to identify the given setters so
 // that they can be replaced if module.importSync is called again with the
 // same key. This avoids potential memory leaks from import declarations
 // inside loops. The compiler generates these keys automatically (and
 // deterministically) when compiling nested import declarations.
 function importSync(id, setters, key) {
-  utils.setESModule(this.exports);
-  var exported = this.require(id);
-
-  if (utils.isObject(setters)) {
-    Entry.getOrCreate(exported).addSetters(this, setters, key);
-  }
+  return this.watch(this.require(id), setters, key);
 }
 
 // Register getter functions for local variables in the scope of an export

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -34,7 +34,7 @@ describe("babel-plugin-transform-es2015-modules-reify", () => {
     const ast = parse(code);
     delete ast.tokens;
     const result = transformFromAst(ast, code, options);
-    assert.ok(/\bmodule\.(?:importSync|export)\b/.test(result.code));
+    assert.ok(/\bmodule\.(?:watch|importSync|export)\b/.test(result.code));
     return result;
   }
 

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -86,9 +86,9 @@ describe("compiler", () => {
     assert.strictEqual(ast.body.length - firstIndex, 6);
 
     isVarDecl(ast.body[firstIndex + 0], ["foo"]);
-    isCallExprStmt(ast.body[firstIndex + 1], "module", "importSync");
+    isCallExprStmt(ast.body[firstIndex + 1], "module", "watch");
     isVarDecl(ast.body[firstIndex + 2], ["bar"]);
-    isCallExprStmt(ast.body[firstIndex + 3], "module", "importSync");
+    isCallExprStmt(ast.body[firstIndex + 3], "module", "watch");
     isCallExprStmt(ast.body[firstIndex + 4], "console", "log");
     isCallExprStmt(ast.body[firstIndex + 5], "module", "export");
   });

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.importSync("assert",{strictEqual:function(v){strictEqual=v}},0);
+"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v}},0);
 
 const obj = {};
 

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,1 +1,1 @@
-"use strict";module.export({Abc:()=>n});module.importSync("./def",{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.importSync("./abc",{"*":function(v,_n){n[_n]=v}},0);
+"use strict";module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0);

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,2 @@
-"use strict";module.importSync("./abc",{"*":function(v,k){exports[k]=v}},0);
+"use strict";module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
 module.export("default",exports.default=("default"));

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({si:()=>cee,c:()=>c});module.importSync("./abc",{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.importSync("./abc.js",{c:function(v){cee=v}},1);
+"use strict";module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
 
 
 module.runModuleSetters(cee += "ee");

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.importSync("assert",{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
+"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
 
 
 

--- a/test/output/mixed-keys/expected.js
+++ b/test/output/mixed-keys/expected.js
@@ -1,1 +1,1 @@
-"use strict";var _1,$1;module.importSync("./a",{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.importSync("./a",{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1);
+"use strict";var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1);

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({outer:()=>outer});function outer() {var ay;module.importSync("./abc",{a:function(v){ay=v}},0);var bee;module.importSync("./abc",{b:function(v){bee=v}},1);var see;module.importSync("./abc",{c:function(v){see=v}},2);
+"use strict";module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a:function(v){ay=v}},0);var bee;module.watch(require("./abc"),{b:function(v){bee=v}},1);var see;module.watch(require("./abc"),{c:function(v){see=v}},2);
 
 
 

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,3 +1,3 @@
-"use strict";function f() {var a,c;module.importSync("./module",{a:function(v){a=v},b:function(v){c=v}},0);
+"use strict";function f() {var a,c;module.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
 
 }

--- a/test/repl-tests.js
+++ b/test/repl-tests.js
@@ -28,7 +28,7 @@ describe("Node REPL", () => {
 
   it("should work with non-global context", (done) => {
     const r = repl.start({ useGlobal: false });
-    const context = createContext({ module });
+    const context = createContext({ module, require });
 
     r.eval(
       'import { strictEqual } from "assert"',


### PR DESCRIPTION
If we choose to go in this direction, we would be removing a significant barrier to interop with CommonJS module systems other than Node (in particular, Webpack and Browserify), since `module.require` would no longer be a requirement, and third-party bundling tools could easily understand dependencies embedded in `module.watch(require(id), ...)` calls.

I'm not committed to module.watch as a method name, though it's short and accurately reflects that the parent module is watching an exports object returned by a child module.