### PR TITLE
Rename module.runModuleSetters to just module.runSetters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,24 +202,23 @@ simply becomes
 exports.default = getDefault();
 ```
 
-### `module.runModuleSetters()`
+### `module.runSetters()`
 
 Now, suppose you change the value of an exported local variable after the
 module has finished loading. Then you need to let the module system know
-about the update, and that's where `module.runModuleSetters` comes in. The
+about the update, and that's where `module.runSetters` comes in. The
 module system calls this method on your behalf whenever a module finishes
 loading, but you can also call it manually, or simply let `reify` generate
-code that calls `module.runModuleSetters` for you whenever you assign to
-an exported local variable.
+code that calls `module.runSetters` for you whenever you assign to an
+exported local variable.
 
-Calling `module.runModuleSetters()` with no arguments causes any setters
-that depend on the current module to be rerun, *but only if the value a
-setter would receive is different from the last value passed to the
-setter*.
+Calling `module.runSetters()` with no arguments causes any setters that
+depend on the current module to be rerun, *but only if the value a setter
+would receive is different from the last value passed to the setter*.
 
-If you pass an argument to `module.runModuleSetters`, the value of that
-argument will be returned as-is, so that you can easily wrap assignment
-expressions with calls to `module.runModuleSetters`:
+If you pass an argument to `module.runSetters`, the value of that argument
+will be returned as-is, so that you can easily wrap assignment expressions
+with calls to `module.runSetters`:
 
 ```js
 export let value = 0;
@@ -237,17 +236,17 @@ module.export({
 });
 let value = 0;
 function increment(by) {
-  return module.runModuleSetters(value += by);
+  return module.runSetters(value += by);
 };
 ```
 
-Note that `module.runModuleSetters(argument)` does not actually use
-`argument`. However, by having `module.runModuleSetters(argument)` return
-`argument` unmodified, we can run setters immediately after the assignment
-without interfering with evaluation of the larger expression.
+Note that `module.runSetters(argument)` does not actually use `argument`.
+However, by having `module.runSetters(argument)` return `argument`
+unmodified, we can run setters immediately after the assignment without
+interfering with evaluation of the larger expression.
 
-Because `module.runModuleSetters` runs any setters that have new values,
-it's also useful for potentially risky expressions that are difficult to
+Because `module.runSetters` runs any setters that have new values, it's
+also useful for potentially risky expressions that are difficult to
 analyze statically:
 
 ```js
@@ -256,7 +255,7 @@ export let value = 0;
 function runCommand(command) {
   // This picks up any new values of any exported local variables that may
   // have been modified by eval.
-  return module.runModuleSetters(eval(command));
+  return module.runSetters(eval(command));
 }
 
 runCommand("value = 1234");
@@ -310,7 +309,7 @@ module.watch(require("./module"), {
 
 Re-exporting default exports ([proposal](https://github.com/leebyron/ecmascript-export-default-from)):
 ```js
-export a, {b, c as d} from "./module";
+export a, { b, c as d } from "./module";
 ```
 becomes
 ```js

--- a/lib/assignment-visitor.js
+++ b/lib/assignment-visitor.js
@@ -44,7 +44,7 @@ function assignmentHelper(visitor, path, childName) {
   const assignedNames = utils.getNamesFromPattern(child);
   const nameCount = assignedNames.length;
 
-  // Wrap assignments to exported identifiers with `module.runModuleSetters`.
+  // Wrap assignments to exported identifiers with `module.runSetters`.
   for (let i = 0; i < nameCount; ++i) {
     if (visitor.exportedLocalNames[assignedNames[i]] === true) {
       wrap(visitor, path);
@@ -59,7 +59,7 @@ function wrap(visitor, path) {
   if (visitor.magicString !== null) {
     visitor.magicString.prependRight(
       value.start,
-      "module.runModuleSetters("
+      "module.runSetters("
     ).appendLeft(value.end, ")");
   }
 
@@ -74,7 +74,7 @@ function wrap(visitor, path) {
         },
         property: {
           type: "Identifier",
-          name: "runModuleSetters"
+          name: "runSetters"
         }
       },
       arguments: [value]

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -10,9 +10,13 @@ exports.enable = function (mod) {
   if (typeof mod.export !== "function" ||
       typeof mod.importSync !== "function") {
     mod.export = moduleExport;
-    mod.importSync = importSync;
     mod.watch = moduleWatch;
-    mod.runModuleSetters = runModuleSetters;
+    mod.runSetters = runSetters;
+
+    // To be deprecated:
+    mod.runModuleSetters = runSetters;
+    mod.importSync = importSync;
+
     return true;
   }
 
@@ -48,8 +52,8 @@ function moduleExport(getters) {
 
   if (this.loaded) {
     // If the module has already been evaluated, then we need to trigger
-    // another round of entry.runModuleSetters calls, which begins by
-    // calling entry.runModuleGetters(module).
+    // another round of entry.runSetters calls, which begins by calling
+    // entry.runModuleGetters(module).
     entry.runSetters();
   }
 }
@@ -57,15 +61,15 @@ function moduleExport(getters) {
 // Platform-specific code should find a way to call this method whenever
 // the module system is about to return module.exports from require. This
 // might happen more than once per module, in case of dependency cycles,
-// so we want Module.prototype.runModuleSetters to run each time.
-function runModuleSetters(valueToPassThrough) {
+// so we want Module.prototype.runSetters to run each time.
+function runSetters(valueToPassThrough) {
   var entry = Entry.get(this.exports);
   if (entry !== null) {
     entry.runSetters();
   }
 
   // Assignments to exported local variables get wrapped with calls to
-  // module.runModuleSetters, so module.runModuleSetters returns the
+  // module.runSetters, so module.runSetters returns the
   // valueToPassThrough parameter to allow the value of the original
   // expression to pass through. For example,
   //
@@ -76,9 +80,9 @@ function runModuleSetters(valueToPassThrough) {
   //
   //   module.export("a", () => a);
   //   var a = 1;
-  //   console.log(module.runModuleSetters(a += 3));
+  //   console.log(module.runSetters(a += 3));
   //
-  // This ensures module.runModuleSetters runs immediately after the
-  // assignment, and does not interfere with the larger computation.
+  // This ensures module.runSetters runs immediately after the assignment,
+  // and does not interfere with the larger computation.
   return valueToPassThrough;
 }

--- a/test/import-tests.js
+++ b/test/import-tests.js
@@ -88,7 +88,7 @@ describe("import declarations", () => {
     assert.strictEqual(b, o.b);
     assert.strictEqual(c, o.c);
     o.c = 4;
-    module.runModuleSetters.call({ exports: o });
+    module.runSetters.call({ exports: o });
     assert.strictEqual(c, 4);
 
     import { value, reset, add } from "./cjs/bridge.js";

--- a/test/output/declarations-basic/expected.js
+++ b/test/output/declarations-basic/expected.js
@@ -7,4 +7,4 @@ function d() {
   return b;
 };
 
-module.runModuleSetters(c = "c");
+module.runSetters(c = "c");

--- a/test/output/eval/expected.js
+++ b/test/output/eval/expected.js
@@ -1,5 +1,5 @@
 "use strict";module.export({value:()=>localValue,run:()=>run});let localValue = "original";
 
 function run(code) {
-  return module.runModuleSetters(eval(code));
+  return module.runSetters(eval(code));
 };

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,7 +1,7 @@
 "use strict";module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
 
 
-module.runModuleSetters(cee += "ee");
+module.runSetters(cee += "ee");
 
 
 function c() {

--- a/test/output/live/expected.js
+++ b/test/output/live/expected.js
@@ -1,9 +1,9 @@
 "use strict";module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
 
 function reset() {
-  return module.runModuleSetters(value = 0);
+  return module.runSetters(value = 0);
 }
 
 function add(x) {
-  module.runModuleSetters(value += x);
+  module.runSetters(value += x);
 };

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -1,6 +1,6 @@
 const assert = require("assert");
 
-describe("module.runModuleSetters", () => {
+describe("module.runSetters", () => {
   it("should be called after eval(...)", () => {
     import { value, run } from "./setter/eval";
 


### PR DESCRIPTION
The redundancy of this method name has always bothered me, so I figured I should deal with it at the same time as the `module.importSync` → `module.watch` changeover (#159), since the risks are essentially the same.

Like `module.importSync`, `module.runModuleSetters` is still defined in `lib/runtime.js`, but it will likely be deprecated and removed in a future version of Reify.