### PR TITLE
Fix ns export when between a default export and exported specifiers.

### DIFF
--- a/lib/parsers/acorn-extensions/dynamic-import.js
+++ b/lib/parsers/acorn-extensions/dynamic-import.js
@@ -19,18 +19,21 @@ exports.enable = function (parser) {
 };
 
 function parseExprAtom(refDestructuringErrors) {
-  const node = this.startNode();
+  const importPos = this.start;
   if (this.eat(tt._import)) {
     if (this.type !== tt.parenL) {
       this.unexpected();
     }
-    return this.finishNode(node, "Import");
+    return this.finishNode(this.startNodeAt(importPos), "Import");
   }
   return Pp.parseExprAtom.call(this, refDestructuringErrors);
 }
 
-function parseStatement(declaration, topLevel, exports) {
-  return this.type === tt._import && this.input.charCodeAt(this.pos) === codeOfLeftParen
-    ? this.parseExpressionStatement(this.startNode(), this.parseExpression())
-    : Pp.parseStatement.call(this, declaration, topLevel, exports);
+function parseStatement(declaration, topLevel, exported) {
+  if (this.type === tt._import &&
+      this.input.charCodeAt(this.pos) === codeOfLeftParen) {
+    // import(...)
+    return this.parseExpressionStatement(this.startNode(), this.parseExpression());
+  }
+  return Pp.parseStatement.call(this, declaration, topLevel, exported);
 }

--- a/lib/parsers/acorn-extensions/export.js
+++ b/lib/parsers/acorn-extensions/export.js
@@ -4,15 +4,8 @@ const acorn = require("acorn");
 const tt = acorn.tokTypes;
 
 exports.enable = function (parser) {
-  parser.checkExports = checkExports;
   parser.parseExport = parseExport;
 };
-
-function checkExports(exported, name) {
-  if (exported !== void 0) {
-    exported[name] = true;
-  }
-}
 
 function parseExport(node, exported) {
   // export ...

--- a/lib/parsers/acorn-extensions/export.js
+++ b/lib/parsers/acorn-extensions/export.js
@@ -32,6 +32,10 @@ function parseExport(node, exported) {
   return parseExportSpecifiersAndSource(this, node, exported);
 }
 
+function getType(parser) {
+  return parser.type;
+}
+
 function isCommaOrFrom(parser) {
   return parser.type === tt.comma || parser.isContextual("from");
 }
@@ -126,7 +130,7 @@ function parseExportNamespaceSpecifiersAndSource(parser, node, exported) {
 }
 
 function parseExportNamespaceSpecifiersMaybe(parser, node, exported) {
-  if (parser.type === tt.comma && peekNextType(parser) === tt.star) {
+  if (parser.type === tt.comma && peekNextWith(parser, getType) === tt.star) {
     parser.next();
     const star = parser.startNode();
     parser.next();
@@ -154,10 +158,6 @@ function parseExportSpecifiersMaybe(parser, node) {
       parser.parseExportSpecifiers()
     );
   }
-}
-
-function peekNextType(parser) {
-  return peekNextWith(parser, () => parser.type);
 }
 
 // Calls the given callback with the state of the parser temporarily advanced

--- a/lib/parsers/acorn-extensions/export.js
+++ b/lib/parsers/acorn-extensions/export.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const acorn = require("acorn");
+const dummyParser = new acorn.Parser;
 const tt = acorn.tokTypes;
 
 exports.enable = function (parser) {
@@ -158,11 +159,8 @@ function parseExportSpecifiersMaybe(parser, node) {
 // by calling this.nextToken(), then rolls the parser back to its original state
 // and returns the result of the callback.
 function peekNextWith(parser, callback) {
-  const old = Object.assign(Object.create(null), parser);
-  parser.nextToken();
-  try {
-    return callback(parser);
-  } finally {
-    Object.assign(parser, old);
-  }
+  dummyParser.input = parser.input;
+  dummyParser.pos = parser.pos;
+  dummyParser.nextToken();
+  return callback(dummyParser);
 }

--- a/lib/parsers/acorn-extensions/export.js
+++ b/lib/parsers/acorn-extensions/export.js
@@ -15,20 +15,26 @@ function checkExports(exported, name) {
 }
 
 function parseExport(node, exported) {
+  // export ...
   this.next();
 
   if (this.type === tt.star) {
+    // ... * [as ns[, { x, y as z }]] from '...';
     return parseExportNamespaceSpecifiersAndSource(this, node, exported);
   }
-  if (isExportDefaultSpecifier(this)) {
+  if (this.type === tt.name && peekNextWith(this, isCommaOrFrom)) {
+    // ... def [, * as ns [, { x, y as z }]] from '...';
     return parseExportDefaultSpecifiersAndSource(this, node, exported);
   }
   if (this.type === tt._default) {
+    // ... default function|class|=...;
     return parseExportDefaultDeclaration(this, node, exported);
   }
   if (this.shouldParseExportStatement()) {
+    // ... var|const|let|function|class ...
     return parseExportNamedDeclaration(this, node, exported);
   }
+  // ... { x, y as z } [from '...'];
   return parseExportSpecifiersAndSource(this, node, exported);
 }
 
@@ -40,17 +46,14 @@ function isCommaOrFrom(parser) {
   return parser.type === tt.comma || parser.isContextual("from");
 }
 
-function isExportDefaultSpecifier(parser) {
-  return parser.type === tt.name && peekNextWith(parser, isCommaOrFrom);
-}
-
 function parseExportDefaultDeclaration(parser, node, exported) {
-  // export default ...;
+  // ... default function|class|=...;
   exported.default = true;
   parser.next();
 
   let isAsync;
   if (parser.type === tt._function || (isAsync = parser.isAsyncFunction())) {
+    // Parse a function declaration.
     const funcNode = parser.startNode();
     if (isAsync) {
       parser.next();
@@ -58,8 +61,10 @@ function parseExportDefaultDeclaration(parser, node, exported) {
     parser.next();
     node.declaration = parser.parseFunction(funcNode, "nullableID", false, isAsync);
   } else if (parser.type === tt._class) {
+    // Parse a class declaration.
     node.declaration = parser.parseClass(parser.startNode(), "nullableID");
   } else {
+    // Parse an assignment expression.
     node.declaration = parser.parseMaybeAssign();
   }
   parser.semicolon();
@@ -67,15 +72,11 @@ function parseExportDefaultDeclaration(parser, node, exported) {
 }
 
 function parseExportDefaultSpecifiersAndSource(parser, node, exported) {
-  // export def from '...';
+  // ... def [, * as ns [, { x, y as z }]] from '...';
   const specifier = parser.startNode();
   specifier.exported = parser.parseIdent(true);
+  node.specifiers = [parser.finishNode(specifier, "ExportDefaultSpecifier")];
 
-  node.specifiers = [
-    parser.finishNode(specifier, "ExportDefaultSpecifier")
-  ];
-
-  // export def [, * as ns [, { x, y as z }]] from '...';
   parseExportNamespaceSpecifiersMaybe(parser, node, exported);
   parseExportSpecifiersMaybe(parser, node);
   parseExportFrom(parser, node);
@@ -83,13 +84,14 @@ function parseExportDefaultSpecifiersAndSource(parser, node, exported) {
 }
 
 function parseExportFrom(parser, node) {
+  // ... from '...';
   parser.expectContextual("from");
   node.source = parser.type === tt.string ? parser.parseExprAtom() : null;
   parser.semicolon();
 }
 
 function parseExportNamedDeclaration(parser, node, exported) {
-  // export var|const|let|function|class ...
+  // ... var|const|let|function|class ...
   node.declaration = parser.parseStatement(true);
   node.source = null;
   node.specifiers = [];
@@ -102,35 +104,35 @@ function parseExportNamedDeclaration(parser, node, exported) {
   return parser.finishNode(node, "ExportNamedDeclaration");
 }
 
-function parseExportNamespaceSpecifiers(parser, node, specifier, exported) {
+function parseExportNamespaceSpecifiers(parser, node, star, exported) {
+  // ... as ns
   parser.expectContextual("as");
-  specifier.exported = parser.parseIdent(true);
-  node.specifiers.push(
-    parser.finishNode(specifier, "ExportNamespaceSpecifier")
-  );
-
-  exported[specifier.exported.name] = true;
+  star.exported = parser.parseIdent(true);
+  node.specifiers.push(parser.finishNode(star, "ExportNamespaceSpecifier"));
+  exported[star.exported.name] = true;
 }
 
 function parseExportNamespaceSpecifiersAndSource(parser, node, exported) {
+  // ... * [as ns[, { x, y as z }]] from '...';
   const star = parser.startNode();
+  let type = "ExportAllDeclaration";
+
   node.specifiers = [];
   parser.next();
 
-  if (! parser.isContextual("as")) {
-    // export * from '...';
-    parseExportFrom(parser, node);
-    return parser.finishNode(node, "ExportAllDeclaration");
+  if (parser.isContextual("as")) {
+    type = "ExportNamedDeclaration";
+    parseExportNamespaceSpecifiers(parser, node, star, exported);
+    parseExportSpecifiersMaybe(parser, node);
   }
-  // export * as ns[, { x, y as z }] from '...';
-  parseExportNamespaceSpecifiers(parser, node, star, exported);
-  parseExportSpecifiersMaybe(parser, node);
   parseExportFrom(parser, node);
-  return parser.finishNode(node, "ExportNamedDeclaration");
+  return parser.finishNode(node, type);
 }
 
 function parseExportNamespaceSpecifiersMaybe(parser, node, exported) {
-  if (parser.type === tt.comma && peekNextWith(parser, getType) === tt.star) {
+  // ... , * as ns
+  if (parser.type === tt.comma &&
+      peekNextWith(parser, getType) === tt.star) {
     parser.next();
     const star = parser.startNode();
     parser.next();
@@ -139,7 +141,7 @@ function parseExportNamespaceSpecifiersMaybe(parser, node, exported) {
 }
 
 function parseExportSpecifiersAndSource(parser, node, exported) {
-  // export { x, y as z } [from '...'];
+  // ... { x, y as z } [from '...'];
   node.declaration = null;
   node.specifiers = parser.parseExportSpecifiers(exported);
 
@@ -152,11 +154,10 @@ function parseExportSpecifiersAndSource(parser, node, exported) {
 }
 
 function parseExportSpecifiersMaybe(parser, node) {
+  // ... , { x, y as z }
   if (parser.eat(tt.comma)) {
-    node.specifiers.push.apply(
-      node.specifiers,
-      parser.parseExportSpecifiers()
-    );
+    const specifiers = node.specifiers;
+    specifiers.push.apply(specifiers, parser.parseExportSpecifiers());
   }
 }
 

--- a/lib/parsers/acorn-extensions/export.js
+++ b/lib/parsers/acorn-extensions/export.js
@@ -12,32 +12,46 @@ function parseExport(node, exported) {
   // export ...
   this.next();
 
-  if (this.type === tt.star) {
-    // ... * [as ns[, { x, y as z }]] from '...';
-    return parseExportNamespaceSpecifiersAndSource(this, node, exported);
-  }
-  if (this.type === tt.name && peekNextWith(this, isCommaOrFrom)) {
-    // ... def [, * as ns [, { x, y as z }]] from '...';
-    return parseExportDefaultSpecifiersAndSource(this, node, exported);
-  }
   if (this.type === tt._default) {
     // ... default function|class|=...;
     return parseExportDefaultDeclaration(this, node, exported);
+  }
+  if (this.type === tt.star && lookahead(this).isContextual("from")) {
+    // ... * from '...';
+    return parseExportNamespace(this, node);
   }
   if (this.shouldParseExportStatement()) {
     // ... var|const|let|function|class ...
     return parseExportNamedDeclaration(this, node, exported);
   }
-  // ... { x, y as z } [from '...'];
-  return parseExportSpecifiersAndSource(this, node, exported);
-}
 
-function getType(parser) {
-  return parser.type;
-}
+  let expectFrom = false;
+  node.specifiers = [];
 
-function isCommaOrFrom(parser) {
-  return parser.type === tt.comma || parser.isContextual("from");
+  do {
+    if (this.type === tt.name) {
+      // ... def [, ...]
+      expectFrom = true;
+      parseExportDefaultSpecifier(this, node);
+    } else if (this.type === tt.star) {
+      // ... * as ns [, ...]
+      expectFrom = true;
+      parseExportNamespaceSpecifier(this, node, exported);
+    } else if (this.type === tt.braceL) {
+      // ... { x, y as z } [, ...]
+      parseExportSpecifiers(this, node);
+    }
+  }
+  while (this.eat(tt.comma));
+
+  if (expectFrom || this.isContextual("from")) {
+    // ... [from '...'];
+    parseExportFrom(this, node, exported);
+  } else {
+    this.semicolon();
+  }
+
+  return this.finishNode(node, "ExportNamedDeclaration");
 }
 
 function parseExportDefaultDeclaration(parser, node, exported) {
@@ -65,16 +79,11 @@ function parseExportDefaultDeclaration(parser, node, exported) {
   return parser.finishNode(node, "ExportDefaultDeclaration");
 }
 
-function parseExportDefaultSpecifiersAndSource(parser, node, exported) {
-  // ... def [, * as ns [, { x, y as z }]] from '...';
+function parseExportDefaultSpecifier(parser, node) {
+  // ... def
   const specifier = parser.startNode();
   specifier.exported = parser.parseIdent(true);
-  node.specifiers = [parser.finishNode(specifier, "ExportDefaultSpecifier")];
-
-  parseExportNamespaceSpecifiersMaybe(parser, node, exported);
-  parseExportSpecifiersMaybe(parser, node);
-  parseExportFrom(parser, node);
-  return parser.finishNode(node, "ExportNamedDeclaration");
+  node.specifiers.push(parser.finishNode(specifier, "ExportDefaultSpecifier"));
 }
 
 function parseExportFrom(parser, node) {
@@ -98,69 +107,32 @@ function parseExportNamedDeclaration(parser, node, exported) {
   return parser.finishNode(node, "ExportNamedDeclaration");
 }
 
-function parseExportNamespaceSpecifiers(parser, node, star, exported) {
-  // ... as ns
+function parseExportNamespace(parser, node) {
+  // ... * from '...';
+  parser.next();
+  node.specifiers = [];
+  parseExportFrom(parser, node);
+  return parser.finishNode(node, "ExportAllDeclaration");
+}
+
+function parseExportNamespaceSpecifier(parser, node, exported) {
+  // ... * as ns
+  const star = parser.startNode();
+  parser.next();
   parser.expectContextual("as");
   star.exported = parser.parseIdent(true);
   node.specifiers.push(parser.finishNode(star, "ExportNamespaceSpecifier"));
   exported[star.exported.name] = true;
 }
 
-function parseExportNamespaceSpecifiersAndSource(parser, node, exported) {
-  // ... * [as ns[, { x, y as z }]] from '...';
-  const starPos = parser.start;
-  let type = "ExportAllDeclaration";
-
-  node.specifiers = [];
-  parser.next();
-
-  if (parser.isContextual("as")) {
-    type = "ExportNamedDeclaration";
-    parseExportNamespaceSpecifiers(parser, node, parser.startNodeAt(starPos), exported);
-    parseExportSpecifiersMaybe(parser, node);
-  }
-  parseExportFrom(parser, node);
-  return parser.finishNode(node, type);
+function parseExportSpecifiers(parser, node) {
+  const specifiers = node.specifiers;
+  specifiers.push.apply(specifiers, parser.parseExportSpecifiers());
 }
 
-function parseExportNamespaceSpecifiersMaybe(parser, node, exported) {
-  // ... , * as ns
-  if (parser.type === tt.comma &&
-      peekNextWith(parser, getType) === tt.star) {
-    parser.next();
-    const star = parser.startNode();
-    parser.next();
-    parseExportNamespaceSpecifiers(parser, node, star, exported);
-  }
-}
-
-function parseExportSpecifiersAndSource(parser, node, exported) {
-  // ... { x, y as z } [from '...'];
-  node.declaration = null;
-  node.specifiers = parser.parseExportSpecifiers(exported);
-
-  if (parser.isContextual("from")) {
-    parseExportFrom(parser, node, exported);
-  } else {
-    parser.semicolon();
-  }
-  return parser.finishNode(node, "ExportNamedDeclaration");
-}
-
-function parseExportSpecifiersMaybe(parser, node) {
-  // ... , { x, y as z }
-  if (parser.eat(tt.comma)) {
-    const specifiers = node.specifiers;
-    specifiers.push.apply(specifiers, parser.parseExportSpecifiers());
-  }
-}
-
-// Calls the given callback with the state of the parser temporarily advanced
-// by calling this.nextToken(), then rolls the parser back to its original state
-// and returns the result of the callback.
-function peekNextWith(parser, callback) {
+function lookahead(parser) {
   dummyParser.input = parser.input;
   dummyParser.pos = parser.pos;
   dummyParser.nextToken();
-  return callback(dummyParser);
+  return dummyParser;
 }

--- a/lib/parsers/acorn-extensions/export.js
+++ b/lib/parsers/acorn-extensions/export.js
@@ -107,7 +107,7 @@ function parseExportNamespaceSpecifiers(parser, node, star, exported) {
 
 function parseExportNamespaceSpecifiersAndSource(parser, node, exported) {
   // ... * [as ns[, { x, y as z }]] from '...';
-  const star = parser.startNode();
+  const starPos = parser.start;
   let type = "ExportAllDeclaration";
 
   node.specifiers = [];
@@ -115,7 +115,7 @@ function parseExportNamespaceSpecifiersAndSource(parser, node, exported) {
 
   if (parser.isContextual("as")) {
     type = "ExportNamedDeclaration";
-    parseExportNamespaceSpecifiers(parser, node, star, exported);
+    parseExportNamespaceSpecifiers(parser, node, parser.startNodeAt(starPos), exported);
     parseExportSpecifiersMaybe(parser, node);
   }
   parseExportFrom(parser, node);

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -14,7 +14,7 @@ Object.keys(files).forEach((absPath) => {
 
   // These files fail to transform with es2015 preset due to problems
   // unrelated to the functionality of the Reify Babel plugin.
-  if (relPath === "dynamic-import-tests.js" ||
+  if (relPath === "export/from-extensions.js" ||
       relPath === "export/some.js"  ||
       relPath === "export-tests.js" ||
       relPath === "import-tests.js" ||
@@ -35,12 +35,13 @@ describe("babel-plugin-transform-es2015-modules-reify", () => {
     const ast = parse(code);
     delete ast.tokens;
     const result = transformFromAst(ast, code, options);
-    assert.ok(/\bmodule\.(?:watch|importSync|export)\b/.test(result.code));
+    assert.ok(/\bmodule\.(?:export|import(?:Sync)?|watch)\b/.test(result.code));
     return result;
   }
 
   Object.keys(filesToTest).forEach((relPath) => {
     const code = filesToTest[relPath];
+    const presets = [es2015Preset];
     const plugins = [[reifyPlugin, {
       generateLetDeclarations: true
     }]];
@@ -50,10 +51,7 @@ describe("babel-plugin-transform-es2015-modules-reify", () => {
     });
 
     it(`compiles ${relPath} with es2015`, () => {
-      check(code, {
-        plugins,
-        presets: [es2015Preset]
-      });
+      check(code, { plugins, presets });
     });
   });
 });

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -1,4 +1,6 @@
-const assert = require("assert");
+import assert from "assert";
+
+const isBabylonParser = process.env.REIFY_PARSER === "babylon";
 
 describe("export declarations", () => {
   import { Script } from "vm";
@@ -214,7 +216,8 @@ describe("export declarations", () => {
     assert.deepEqual(foo, { a: "a", b: "b", c: "c" });
   });
 
-  it("should support export-from extensions", () => {
+  (isBabylonParser ? xit : it)(
+  "should support export-from extensions", () => {
     import {
       def1, def2, def3, def4,
       ns1, ns2, ns3, ns4,

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -216,9 +216,9 @@ describe("export declarations", () => {
 
   it("should support export-from extensions", () => {
     import {
-      def1, def2, def3,
-      ns1, ns2, ns3,
-      a, b, c, d
+      def1, def2, def3, def4,
+      ns1, ns2, ns3, ns4,
+      a, b, c, d, e
     } from "./export/from-extensions";
 
     import def, {
@@ -226,11 +226,13 @@ describe("export declarations", () => {
       b as _b,
       b as _c,
       c as _d,
+      c as _e,
     } from "./misc/abc";
 
     assert.strictEqual(def, def1);
     assert.strictEqual(def, def2);
     assert.strictEqual(def, def3);
+    assert.strictEqual(def, def4);
 
     function checkNS(ns) {
       assert.deepEqual(ns, def);
@@ -240,11 +242,13 @@ describe("export declarations", () => {
     checkNS(ns1);
     checkNS(ns2);
     checkNS(ns3);
+    checkNS(ns4);
 
     assert.strictEqual(a, _a);
     assert.strictEqual(b, _b);
     assert.strictEqual(c, _c);
     assert.strictEqual(d, _d);
+    assert.strictEqual(e, _e);
   });
 
   it("should support export { default } from ... syntax", () => {

--- a/test/export/from-extensions.js
+++ b/test/export/from-extensions.js
@@ -1,5 +1,6 @@
-export def1 from "../misc/abc";
 export * as ns1 from "../misc/abc";
-export def2, * as ns2 from "../misc/abc";
-export def3, { a, b as c } from "../misc/abc";
-export * as ns3, { b, c as d } from "../misc/abc";
+export * as ns2, { a, b as c } from "../misc/abc";
+export def1 from "../misc/abc";
+export def2, { b, c as d } from "../misc/abc";
+export def3, * as ns3 from "../misc/abc";
+export def4, * as ns4, { c as e } from "../misc/abc";

--- a/test/transform-tests.js
+++ b/test/transform-tests.js
@@ -28,18 +28,17 @@ describe("compiler.transform", () => {
   it("gives the same results as compile with babylon", () => {
     check({
       ast: true,
-      parse: require("../lib/parsers/babylon.js").parse
+      parse: require("../lib/parsers/babylon.js").parse,
+      filter: (relPath) => {
+        return relPath !== "export/from-extensions.js";
+      }
     });
   }).timeout(5000);
 
   it("gives the same results as compile with acorn", () => {
     check({
       ast: true,
-      parse: require("../lib/parsers/acorn.js").parse,
-      filter: (relPath) => {
-        // Acorn can't parse this file, so we skip it.
-        return relPath !== "export/from-extensions.js";
-      }
+      parse: require("../lib/parsers/acorn.js").parse
     });
   }).timeout(5000);
 });


### PR DESCRIPTION
Hey @benjamn. I found this bug but the \babylon compiler. Its having problems with:
```
export def4, * as ns4, { c as e } from "../misc/abc";
```
The acorn parser works because of our extension (bug fix).

I've skipped the from-extensions from other babylon specific tests, but it will still error when using the babylon parser (the first iteration of the run.sh).