### PR TITLE
Wrap module bodies with module.run(function(){...}).

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -66,6 +66,13 @@ exports.compile = function (code, options) {
     });
 
     importExportVisitor.finalizeHoisting();
+
+    if (getOption(options, "wrapWithRun")) {
+      result.code = "module.run(function(){" +
+        magicString.toString() + "//*/\n});";
+
+      return result;
+    }
   }
 
   result.code = magicString.toString();

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -67,7 +67,7 @@ exports.compile = function (code, options) {
 
     importExportVisitor.finalizeHoisting();
 
-    if (getOption(options, "wrapWithRun")) {
+    if (! getOption(options, "repl")) {
       result.code = "module.run(function(){" +
         magicString.toString() + "//*/\n});";
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,11 @@ const defaultOptions = {
   // If not false, "use strict" will be added to any modules with at least
   // one import or export declaration.
   enforceStrictMode: true,
-  wrapWithRun: true,
+  // If true, generate code appropriate for an interactive REPL session.
+  // In particular, in the REPL we should not wrap individual commands
+  // with module.run(function(){...}), and options.repl also implies the
+  // falsity of options.generateLetDeclarations (if unspecified).
+  repl: false,
   generateArrowFunctions: true,
   generateLetDeclarations: false,
   sourceType: "unambiguous",
@@ -18,8 +22,21 @@ const defaultOptions = {
 };
 
 function get(options, name) {
-  const result = hasOwn.call(options, name) ? options[name] : void 0;
-  return result === void 0 ? defaultOptions[name] : result;
+  if (hasOwn.call(options, name)) {
+    const result = options[name];
+    if (result !== void 0) {
+      return result;
+    }
+  }
+
+  if (name === "generateLetDeclarations" &&
+      hasOwn.call(options, "repl")) {
+    // If options.generateLetDeclarations is unspecified and options.repl
+    // is specified, return true iff options.repl is falsy.
+    return ! options.repl;
+  }
+
+  return defaultOptions[name];
 }
 
 exports.get = get;

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,7 @@ const defaultOptions = {
   // If not false, "use strict" will be added to any modules with at least
   // one import or export declaration.
   enforceStrictMode: true,
-  wrapWithRun: false,
+  wrapWithRun: true,
   generateArrowFunctions: true,
   generateLetDeclarations: false,
   sourceType: "unambiguous",

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,6 +7,7 @@ const defaultOptions = {
   // If not false, "use strict" will be added to any modules with at least
   // one import or export declaration.
   enforceStrictMode: true,
+  wrapWithRun: false,
   generateArrowFunctions: true,
   generateLetDeclarations: false,
   sourceType: "unambiguous",

--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -20,6 +20,7 @@ exports.enable = function (mod) {
     mod.export = moduleExport;
     mod.exportDefault = moduleExportDefault;
     mod.import = moduleImport;
+    mod.run = moduleRun;
     mod.runSetters = runSetters;
     mod.watch = watch;
 
@@ -32,6 +33,12 @@ exports.enable = function (mod) {
 
   return false;
 };
+
+function moduleRun(wrapperFunc) {
+  wrapperFunc();
+  this.loaded = true;
+  this.runSetters();
+}
 
 // If key is provided, it will be used to identify the given setters so
 // that they can be replaced if module.importSync is called again with the

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -70,6 +70,10 @@ function toCompileOptions(options) {
     } else if (ext === ".mjs") {
       compileOptions.sourceType = "module";
     }
+
+    compileOptions.wrapWithRun = true;
+  } else {
+    compileOptions.wrapWithRun = false;
   }
 
   return compileOptions;

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -58,6 +58,10 @@ function toCompileOptions(options) {
     compileOptions.parse = dynRequire(config.parser).parse;
   }
 
+  if (options.repl === true) {
+    compileOptions.repl = true;
+  }
+
   if (typeof filePath === "string") {
     let ext = path.extname(filePath);
 
@@ -70,10 +74,6 @@ function toCompileOptions(options) {
     } else if (ext === ".mjs") {
       compileOptions.sourceType = "module";
     }
-
-    compileOptions.wrapWithRun = true;
-  } else {
-    compileOptions.wrapWithRun = false;
   }
 
   return compileOptions;

--- a/node/repl-hook.js
+++ b/node/repl-hook.js
@@ -25,7 +25,7 @@ if (utils.isREPL(rootModule)) {
     const cacheValue = pkgInfo.cache[cacheFilename];
     code = typeof cacheValue === "string"
       ? cacheValue
-      : compile(code, { cacheFilename, pkgInfo });
+      : compile(code, { cacheFilename, pkgInfo, repl: true });
 
     return func.call(this, code, options);
   });

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -299,10 +299,7 @@ describe("compiler", () => {
       'from "assert";'
     ].join("\r\n");
 
-    const result = compile(code, {
-      wrapWithRun: false
-    }).code;
-
+    const result = compile(code, { repl: true }).code;
     assert.ok(result.endsWith("\r\n".repeat(5)));
   });
 });

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -105,13 +105,13 @@ describe("compiler", () => {
       enforceStrictMode: false
     }).code;
 
-    assert.ok(! withoutStrict.startsWith('"use strict"'));
+    assert.ok(! withoutStrict.startsWith('module.run(function(){"use strict"'));
 
     const withStrict = compile(source, {
       enforceStrictMode: true
     }).code;
 
-    assert.ok(withStrict.startsWith('"use strict"'));
+    assert.ok(withStrict.startsWith('module.run(function(){"use strict"'));
 
     // No options.enforceStrictMode is the same as
     // { enforceStrictMode: true }.
@@ -119,7 +119,7 @@ describe("compiler", () => {
       source
     ).code;
 
-    assert.ok(defaultStrict.startsWith('"use strict"'));
+    assert.ok(defaultStrict.startsWith('module.run(function(){"use strict"'));
   });
 
   it("should respect options.generateArrowFunctions", () => {
@@ -160,13 +160,13 @@ describe("compiler", () => {
       generateLetDeclarations: true
     }).code;
 
-    assert.ok(withLet.startsWith('"use strict";let foo;'));
+    assert.ok(withLet.startsWith('module.run(function(){"use strict";let foo;'));
 
     const withoutLet = compile(source, {
       generateLetDeclarations: false
     }).code;
 
-    assert.ok(withoutLet.startsWith('"use strict";var foo;'));
+    assert.ok(withoutLet.startsWith('module.run(function(){"use strict";var foo;'));
 
     // No options.generateLetDeclarations is the same as
     // { generateLetDeclarations: false }.
@@ -174,7 +174,7 @@ describe("compiler", () => {
       source
     ).code;
 
-    assert.ok(defaultLet.startsWith('"use strict";var foo;'));
+    assert.ok(defaultLet.startsWith('module.run(function(){"use strict";var foo;'));
   });
 
   it("should allow pre-parsed ASTs via options.parse", () => {
@@ -192,7 +192,7 @@ describe("compiler", () => {
     });
 
     assert.strictEqual(result.ast, null);
-    assert.ok(result.code.startsWith('"use strict";let foo'));
+    assert.ok(result.code.startsWith('module.run(function(){"use strict";let foo'));
     assert.ok(result.code.includes('"./+@#"'));
   });
 
@@ -205,19 +205,19 @@ describe("compiler", () => {
       sourceType: "module"
     }).code;
 
-    assert.ok(moduleType.startsWith('"use strict"'));
+    assert.ok(moduleType.startsWith('module.run(function(){"use strict"'));
 
     const unambiguousAsCJS = compile(source, {
       sourceType: "unambiguous"
     }).code;
 
-    assert.ok(! unambiguousAsCJS.startsWith('"use strict"'));
+    assert.ok(! unambiguousAsCJS.startsWith('module.run(function(){"use strict"'));
 
     const unambiguousAsESM = compile('import "a"\n' + source, {
       sourceType: "unambiguous"
     }).code;
 
-    assert.ok(unambiguousAsESM.startsWith('"use strict"'));
+    assert.ok(unambiguousAsESM.startsWith('module.run(function(){"use strict"'));
 
     const scriptType = compile('import "a"\n' + source, {
       sourceType: "script"
@@ -231,7 +231,7 @@ describe("compiler", () => {
       source
     ).code;
 
-    assert.ok(! defaultType.startsWith('"use strict"'));
+    assert.ok(! defaultType.startsWith('module.run(function(){"use strict"'));
   });
 
   it("should transform default export declaration to expression", () => {
@@ -284,7 +284,7 @@ describe("compiler", () => {
     ].join("\n");
 
     const withShebang = compile(code).code;
-    assert.ok(withShebang.startsWith('"use strict";var foo'));
+    assert.ok(withShebang.startsWith('module.run(function(){"use strict";var foo'));
   });
 
   it("should preserve crlf newlines", () => {
@@ -299,7 +299,10 @@ describe("compiler", () => {
       'from "assert";'
     ].join("\r\n");
 
-    const result = compile(code).code;
+    const result = compile(code, {
+      wrapWithRun: false
+    }).code;
+
     assert.ok(result.endsWith("\r\n".repeat(5)));
   });
 });

--- a/test/output/anon-class/expected.js
+++ b/test/output/anon-class/expected.js
@@ -1,5 +1,7 @@
-"use strict";module.exportDefault(class {
+module.run(function(){"use strict";module.exportDefault(class {
   constructor(value) {
     this.value = value;
   }
+});
+//*/
 });

--- a/test/output/declarations-basic/expected.js
+++ b/test/output/declarations-basic/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({c:()=>c,d:()=>d});module.export({a:()=>a,b:()=>b},true);const a = 1;
+module.run(function(){"use strict";module.export({c:()=>c,d:()=>d});module.export({a:()=>a,b:()=>b},true);const a = 1;
 const b = function () {
   return d;
 };
@@ -8,3 +8,5 @@ function d() {
 };
 
 module.runSetters(c = "c");
+//*/
+});

--- a/test/output/default-expression/expected.js
+++ b/test/output/default-expression/expected.js
@@ -1,5 +1,7 @@
-"use strict";let count = 0;
+module.run(function(){"use strict";let count = 0;
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.
 module.exportDefault((count++, count));
+//*/
+});

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v}},0);
+module.run(function(){"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v}},0);
 
 const obj = {};
 
@@ -11,3 +11,5 @@ function check(g) {
   strictEqual(f(), obj);
   strictEqual(g(), obj);
 }
+//*/
+});

--- a/test/output/eval/expected.js
+++ b/test/output/eval/expected.js
@@ -1,5 +1,7 @@
-"use strict";module.export({value:()=>localValue,run:()=>run});let localValue = "original";
+module.run(function(){"use strict";module.export({value:()=>localValue,run:()=>run});let localValue = "original";
 
 function run(code) {
   return module.runSetters(eval(code));
 };
+//*/
+});

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,1 +1,5 @@
-"use strict";module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0);
+module.run(function(){"use strict";module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0);
+
+
+//*/
+});

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,4 @@
-"use strict";module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
+module.run(function(){"use strict";module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
 module.exportDefault("default");
+//*/
+});

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
+module.run(function(){"use strict";module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
 
 
 module.runSetters(cee += "ee");
@@ -7,3 +7,5 @@ module.runSetters(cee += "ee");
 function c() {
   return "c";
 }
+//*/
+});

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
+module.run(function(){"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
 
 
 
@@ -15,3 +15,5 @@ function check()
   const line = +error.stack.split("\n")[1].split(":")[1];
   strictEqual(line, 14);
 }
+//*/
+});

--- a/test/output/live/expected.js
+++ b/test/output/live/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
+module.run(function(){"use strict";module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
 
 function reset() {
   return module.runSetters(value = 0);
@@ -7,3 +7,5 @@ function reset() {
 function add(x) {
   module.runSetters(value += x);
 };
+//*/
+});

--- a/test/output/mixed-keys/expected.js
+++ b/test/output/mixed-keys/expected.js
@@ -1,1 +1,4 @@
-"use strict";var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1);
+module.run(function(){"use strict";var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1);
+
+//*/
+});

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,4 +1,6 @@
-"use strict";var module1=module;module1.export({id:()=>id,name:()=>name},true);const path = require("path");
+module.run(function(){"use strict";var module1=module;module1.export({id:()=>id,name:()=>name},true);const path = require("path");
 
 const id = module.id,
   name = path.basename(__filename);
+//*/
+});

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a:function(v){ay=v}},0);var bee;module.watch(require("./abc"),{b:function(v){bee=v}},1);var see;module.watch(require("./abc"),{c:function(v){see=v}},2);
+module.run(function(){"use strict";module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a:function(v){ay=v}},0);var bee;module.watch(require("./abc"),{b:function(v){bee=v}},1);var see;module.watch(require("./abc"),{c:function(v){see=v}},2);
 
 
 
@@ -8,3 +8,5 @@
     see
   ];
 }
+//*/
+});

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,3 +1,5 @@
-"use strict";var module1=module;function f() {var a,c;module1.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
+module.run(function(){"use strict";var module1=module;function f() {var a,c;module1.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
 
 }
+//*/
+});


### PR DESCRIPTION
This solves several subtle problems:

1. It ensures modules run with an undefined `this` binding.
2. It ensures we call `module.runSetters()` after any compiled module finishes loading, even if we are not able to patch runtime methods like `Module.prototype.{_compile,load}` (e.g. in Webpack).
3. It allows setting `module.loaded` even in environments where that wouldn't normally happen, so that we can rely on it elsewhere.

This PR should not be merged yet, as it still needs tests.