### PR TITLE
Keep unique reference to `module` to avoid conflict with user variables.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -49,8 +49,10 @@ exports.compile = function (code, options) {
     return result;
   }
 
-  const rootPath = new FastPath(ast);
+  options.moduleId = options.moduleId ||
+    makeUniqueIdQuickly("module", code);
 
+  const rootPath = new FastPath(ast);
   importExportVisitor.visit(rootPath, code, options);
   result.identical = ! importExportVisitor.madeChanges;
 
@@ -67,9 +69,27 @@ exports.compile = function (code, options) {
   }
 
   result.code = magicString.toString();
+
   return result;
 };
 
 exports.transform = function (ast, options) {
   return dynRequire("./transform.js")(ast, options);
 };
+
+function makeUniqueIdQuickly(prefix, source) {
+  const scanRegExp = new RegExp("\\b" + prefix + "(\\d*)\\b", "g");
+  let match, max = -1;
+
+  while ((match = scanRegExp.exec(source))) {
+    max = Math.max(max, +(match[1] || 0));
+  }
+
+  if (max >= 0) {
+    return prefix + (max + 1);
+  }
+
+  return prefix;
+}
+
+exports.makeUniqueId = makeUniqueIdQuickly;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -50,7 +50,7 @@ exports.compile = function (code, options) {
   }
 
   options.moduleAlias = options.moduleAlias ||
-    makeUniqueIdQuickly("module", code);
+    makeUniqueId("module", code);
 
   const rootPath = new FastPath(ast);
   importExportVisitor.visit(rootPath, code, options);
@@ -77,7 +77,7 @@ exports.transform = function (ast, options) {
   return dynRequire("./transform.js")(ast, options);
 };
 
-function makeUniqueIdQuickly(prefix, source) {
+function makeUniqueId(prefix, source) {
   const scanRegExp = new RegExp("\\b" + prefix + "(\\d*)\\b", "g");
   let match, max = -1;
 
@@ -92,4 +92,4 @@ function makeUniqueIdQuickly(prefix, source) {
   return prefix;
 }
 
-exports.makeUniqueId = makeUniqueIdQuickly;
+exports.makeUniqueId = makeUniqueId;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -49,7 +49,7 @@ exports.compile = function (code, options) {
     return result;
   }
 
-  options.moduleId = options.moduleId ||
+  options.moduleAlias = options.moduleAlias ||
     makeUniqueIdQuickly("module", code);
 
   const rootPath = new FastPath(ast);

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -26,6 +26,12 @@ class ImportExportVisitor extends Visitor {
         codeToInsert += '"use strict";';
       }
 
+      if (bodyInfo.parent.type === "Program" &&
+          this.moduleId !== "module") {
+        codeToInsert += this.generateLetDeclarations ? "const " : "var ";
+        codeToInsert += this.moduleId + "=module;";
+      }
+
       const addExportsMap = (map, constant) => {
         const namedExports = toModuleExport(this, map, constant);
         if (namedExports) {
@@ -108,6 +114,7 @@ class ImportExportVisitor extends Visitor {
     this.parse = getOption(options, "parse");
     this.removals = [];
     this.sourceType = getOption(options, "sourceType");
+    this.moduleId = getOption(options, "moduleId");
   }
 
   visitProgram(path) {
@@ -129,8 +136,9 @@ class ImportExportVisitor extends Visitor {
 
     if (callee.type === "Import") {
       this.madeChanges = true;
-      overwrite(this, callee.start, callee.end, "module.import");
+      overwrite(this, callee.start, callee.end, this.moduleId + ".import");
     }
+
     this.visitChildren(path);
   }
 
@@ -183,9 +191,9 @@ class ImportExportVisitor extends Visitor {
     }
 
     hoistedCode += toModuleImport(
+      this,
       getSourceString(this, decl),
-      computeSpecifierMap(decl.specifiers),
-      makeUniqueKey(this)
+      computeSpecifierMap(decl.specifiers)
     );
 
     hoistImports(this, path, hoistedCode);
@@ -195,7 +203,7 @@ class ImportExportVisitor extends Visitor {
     const decl = path.getValue();
     const hoistedCode = pad(
       this,
-      "module.watch(require(" + getSourceString(this, decl) + ")",
+      this.moduleId + ".watch(require(" + getSourceString(this, decl) + ")",
       decl.start,
       decl.source.start
     ) + pad(
@@ -230,7 +238,7 @@ class ImportExportVisitor extends Visitor {
       path.call(this.visitWithoutReset, "declaration");
       assert.strictEqual(decl.declaration, dd);
 
-      let prefix = "module.exportDefault(";
+      let prefix = this.moduleId + ".exportDefault(";
       let suffix = ");";
 
       if (dd.type === "SequenceExpression") {
@@ -249,8 +257,8 @@ class ImportExportVisitor extends Visitor {
 
       if (this.modifyAST) {
         // A Function or Class declaration has become an expression on the
-        // right side of the _exportDefaultPrefix assignment above so change
-        // the AST appropriately
+        // right side of the exportDefaultPrefix assignment above so
+        // change the AST appropriately
         if (dd.type === "FunctionDeclaration") {
           dd.type = "FunctionExpression";
         } else if (dd.type === "ClassDeclaration") {
@@ -259,7 +267,7 @@ class ImportExportVisitor extends Visitor {
 
         // Almost every JS parser parses this expression the same way, but
         // we should still give custom parsers a chance to parse it.
-        let ast = this.parse("module.exportDefault(ARG);");
+        let ast = this.parse(this.moduleId + ".exportDefault(ARG);");
         if (ast.type === "File") ast = ast.program;
         assert.strictEqual(ast.type, "Program");
 
@@ -341,9 +349,9 @@ class ImportExportVisitor extends Visitor {
         // Even though the compiled code uses module.importSync, it should
         // still be hoisted as an export, i.e. before actual imports.
         hoistExports(this, path, toModuleImport(
+          this,
           getSourceString(this, decl),
-          specifierMap,
-          makeUniqueKey(this)
+          specifierMap
         ));
 
       } else {
@@ -774,8 +782,8 @@ function safeParam(param, locals) {
   return safeParam("_" + param, locals);
 }
 
-function toModuleImport(source, specifierMap, uniqueKey) {
-  let code = "module.watch(require(" + source + ")";
+function toModuleImport(visitor, source, specifierMap) {
+  let code = visitor.moduleId + ".watch(require(" + source + ")";
   const importedNames = Object.keys(specifierMap);
   const nameCount = importedNames.length;
 
@@ -830,7 +838,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
     }
   }
 
-  code += "}," + uniqueKey + ");";
+  code += "}," + makeUniqueKey(visitor) + ");";
 
   return code;
 }
@@ -845,7 +853,7 @@ function toModuleExport(visitor, specifierMap, constant) {
   }
 
   const lastIndex = keyCount - 1;
-  code += "module.export({";
+  code += visitor.moduleId + ".export({";
 
   for (let i = 0; i < keyCount; ++i) {
     const exported = exportedKeys[i];

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -27,9 +27,9 @@ class ImportExportVisitor extends Visitor {
       }
 
       if (bodyInfo.parent.type === "Program" &&
-          this.moduleId !== "module") {
+          this.moduleAlias !== "module") {
         codeToInsert += this.generateLetDeclarations ? "const " : "var ";
-        codeToInsert += this.moduleId + "=module;";
+        codeToInsert += this.moduleAlias + "=module;";
       }
 
       const addExportsMap = (map, constant) => {
@@ -114,7 +114,7 @@ class ImportExportVisitor extends Visitor {
     this.parse = getOption(options, "parse");
     this.removals = [];
     this.sourceType = getOption(options, "sourceType");
-    this.moduleId = getOption(options, "moduleId");
+    this.moduleAlias = getOption(options, "moduleAlias");
   }
 
   visitProgram(path) {
@@ -136,7 +136,7 @@ class ImportExportVisitor extends Visitor {
 
     if (callee.type === "Import") {
       this.madeChanges = true;
-      overwrite(this, callee.start, callee.end, this.moduleId + ".import");
+      overwrite(this, callee.start, callee.end, this.moduleAlias + ".import");
     }
 
     this.visitChildren(path);
@@ -203,7 +203,7 @@ class ImportExportVisitor extends Visitor {
     const decl = path.getValue();
     const hoistedCode = pad(
       this,
-      this.moduleId + ".watch(require(" + getSourceString(this, decl) + ")",
+      this.moduleAlias + ".watch(require(" + getSourceString(this, decl) + ")",
       decl.start,
       decl.source.start
     ) + pad(
@@ -238,7 +238,7 @@ class ImportExportVisitor extends Visitor {
       path.call(this.visitWithoutReset, "declaration");
       assert.strictEqual(decl.declaration, dd);
 
-      let prefix = this.moduleId + ".exportDefault(";
+      let prefix = this.moduleAlias + ".exportDefault(";
       let suffix = ");";
 
       if (dd.type === "SequenceExpression") {
@@ -267,7 +267,7 @@ class ImportExportVisitor extends Visitor {
 
         // Almost every JS parser parses this expression the same way, but
         // we should still give custom parsers a chance to parse it.
-        let ast = this.parse(this.moduleId + ".exportDefault(ARG);");
+        let ast = this.parse(this.moduleAlias + ".exportDefault(ARG);");
         if (ast.type === "File") ast = ast.program;
         assert.strictEqual(ast.type, "Program");
 
@@ -783,7 +783,7 @@ function safeParam(param, locals) {
 }
 
 function toModuleImport(visitor, source, specifierMap) {
-  let code = visitor.moduleId + ".watch(require(" + source + ")";
+  let code = visitor.moduleAlias + ".watch(require(" + source + ")";
   const importedNames = Object.keys(specifierMap);
   const nameCount = importedNames.length;
 
@@ -853,7 +853,7 @@ function toModuleExport(visitor, specifierMap, constant) {
   }
 
   const lastIndex = keyCount - 1;
-  code += visitor.moduleId + ".export({";
+  code += visitor.moduleAlias + ".export({";
 
   for (let i = 0; i < keyCount; ++i) {
     const exported = exportedKeys[i];

--- a/lib/options.js
+++ b/lib/options.js
@@ -10,7 +10,7 @@ const defaultOptions = {
   generateArrowFunctions: true,
   generateLetDeclarations: false,
   sourceType: "unambiguous",
-  moduleId: "module",
+  moduleAlias: "module",
   get parse () {
     return require("./parsers/default.js").parse;
   }

--- a/lib/options.js
+++ b/lib/options.js
@@ -10,6 +10,7 @@ const defaultOptions = {
   generateArrowFunctions: true,
   generateLetDeclarations: false,
   sourceType: "unambiguous",
+  moduleId: "module",
   get parse () {
     return require("./parsers/default.js").parse;
   }

--- a/packages/babel-plugin-transform-es2015-modules-reify/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-reify/index.js
@@ -76,7 +76,7 @@ module.exports = function () {
 
         var code = path.hub.file.code;
         if (typeof code === "string") {
-          transformOptions.moduleId =
+          transformOptions.moduleAlias =
             compiler.makeUniqueId("module", code);
         }
 

--- a/packages/babel-plugin-transform-es2015-modules-reify/index.js
+++ b/packages/babel-plugin-transform-es2015-modules-reify/index.js
@@ -1,5 +1,5 @@
 module.exports = function () {
-  var transform = require("reify/lib/compiler.js").transform;
+  var compiler = require("reify/lib/compiler.js");
   var parse = require("reify/lib/parsers/babylon.js").parse;
   var validators = require("babel-types/lib/validators");
   var ibs = validators.isBlockScoped;
@@ -74,7 +74,16 @@ module.exports = function () {
           parse: parse
         };
 
-        transform(path.node, Object.assign(transformOptions, this.opts));
+        var code = path.hub.file.code;
+        if (typeof code === "string") {
+          transformOptions.moduleId =
+            compiler.makeUniqueId("module", code);
+        }
+
+        compiler.transform(
+          path.node,
+          Object.assign(transformOptions, this.opts)
+        );
       }
     }
   };

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -7,6 +7,8 @@ import reifyPlugin from "babel-plugin-transform-es2015-modules-reify";
 import es2015Preset from "babel-preset-es2015";
 
 const filesToTest = Object.create(null);
+const methodNameRegExp =
+  /\bmodule\d*\.(?:watch|importSync|export(?:Default)?)\b/;
 
 Object.keys(files).forEach((absPath) => {
   const code = files[absPath];
@@ -36,7 +38,7 @@ describe("babel-plugin-transform-es2015-modules-reify", () => {
     const ast = parse(code);
     delete ast.tokens;
     const result = transformFromAst(ast, code, options);
-    assert.ok(/\bmodule\.(?:export(?:Default)?|import(?:Sync)?|watch)\b/.test(result.code));
+    assert.ok(methodNameRegExp.test(result.code));
     return result;
   }
 

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -31,6 +31,12 @@ describe("compiler", () => {
     assert.ok(/unexpected/i.test(error.message));
   });
 
+  it("should choose a unique module identifier", () => {
+    const module = null, module2 = null;
+    import { a } from "./misc/abc";
+    assert.strictEqual(a, "a");
+  });
+
   it("should be enabled for packages that depend on reify", () => {
     import a from "enabled";
     assert.strictEqual(a, assert);

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({id:()=>id,name:()=>name},true);const path = require("path");
+"use strict";var module1=module;module1.export({id:()=>id,name:()=>name},true);const path = require("path");
 
 const id = module.id,
   name = path.basename(__filename);

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,3 +1,3 @@
-"use strict";function f() {var a,c;module.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
+"use strict";var module1=module;function f() {var a,c;module1.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
 
 }

--- a/test/transform-tests.js
+++ b/test/transform-tests.js
@@ -19,7 +19,7 @@ describe("compiler.transform", () => {
       const code = files[absPath];
       const ast = options.parse(code);
 
-      options.moduleId = makeUniqueId("module", code);
+      options.moduleAlias = makeUniqueId("module", code);
 
       transform(ast, options);
 

--- a/test/transform-tests.js
+++ b/test/transform-tests.js
@@ -1,6 +1,10 @@
 import assert from "assert";
 import { relative } from "path";
-import { compile, transform } from "../lib/compiler.js";
+import {
+  compile,
+  transform,
+  makeUniqueId,
+} from "../lib/compiler.js";
 import { prettyPrint } from "recast";
 import { files } from "./all-files.js";
 
@@ -14,6 +18,8 @@ describe("compiler.transform", () => {
 
       const code = files[absPath];
       const ast = options.parse(code);
+
+      options.moduleId = makeUniqueId("module", code);
 
       transform(ast, options);
 


### PR DESCRIPTION
The `makeUniqueIdQuickly` function scans the source of the module for anything that looks like a `/\bmodule\d*\b/` identifier, then returns an identifier name starting with `module` and ending with a numeric suffix (if necessary) that is guaranteed not to exist anywhere in the source.

Fixes #139.