### PR TITLE
Simplify module.export in order to implement #134

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -67,7 +67,7 @@ Entry.getOrCreate = function (exported) {
   return entry;
 };
 
-Ep.addGetters = function (getters) {
+Ep.addGetters = function (getters, constant) {
   var names = Object.keys(getters);
   var nameCount = names.length;
 
@@ -81,6 +81,7 @@ Ep.addGetters = function (getters) {
         // Should this throw if this.getters[name] exists?
         ! (name in this.getters)) {
       this.getters[name] = getter;
+      getter.constant = !! constant;
     }
   }
 };

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -70,6 +70,7 @@ Entry.getOrCreate = function (exported) {
 Ep.addGetters = function (getters, constant) {
   var names = Object.keys(getters);
   var nameCount = names.length;
+  constant = !! constant;
 
   for (var i = 0; i < nameCount; ++i) {
     var name = names[i];
@@ -81,7 +82,7 @@ Ep.addGetters = function (getters, constant) {
         // Should this throw if this.getters[name] exists?
         ! (name in this.getters)) {
       this.getters[name] = getter;
-      getter.constant = !! constant;
+      getter.constant = constant;
       getter.runCount = 0;
     }
   }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -82,6 +82,7 @@ Ep.addGetters = function (getters, constant) {
         ! (name in this.getters)) {
       this.getters[name] = getter;
       getter.constant = !! constant;
+      getter.runCount = 0;
     }
   }
 };
@@ -258,6 +259,23 @@ function forEachSetter(entry, names, callback) {
 
       } else {
         call(setters[key], name, value, callback);
+
+        var getter = entry.getters[name];
+        if (typeof getter === "function" &&
+            // Sometimes a getter function will throw because it's called
+            // before the variable it's supposed to return has been
+            // initialized, so we need to know that the getter function
+            // has run to completion at least once.
+            getter.runCount > 0 &&
+            getter.constant) {
+          // If we happen to know that this getter function has run
+          // successfully, and will never return a different value, then
+          // we can forget the corresponding setter, because we've already
+          // reported that constant value. Note that we can't forget the
+          // getter, because we need to remember the original value in
+          // case anyone tampers with entry.exports[name].
+          delete setters[key];
+        }
       }
     }
   }
@@ -290,8 +308,11 @@ function makeUniqueKey() {
 }
 
 function runGetter(entry, name) {
+  var getter = entry.getters[name];
   try {
-    return entry.getters[name]();
+    var result = getter();
+    ++getter.runCount;
+    return result;
   } catch (e) {}
   return GETTER_ERROR;
 }

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -26,14 +26,15 @@ class ImportExportVisitor extends Visitor {
         codeToInsert += '"use strict";';
       }
 
-      const namedExports = toModuleExport(
-        this,
-        bodyInfo.hoistedExportsMap
-      );
+      const addExportsMap = (map, constant) => {
+        const namedExports = toModuleExport(this, map, constant);
+        if (namedExports) {
+          codeToInsert += namedExports;
+        }
+      };
 
-      if (namedExports) {
-        codeToInsert += namedExports;
-      }
+      addExportsMap(bodyInfo.hoistedExportsMap, false);
+      addExportsMap(bodyInfo.hoistedConstExportsMap, true);
 
       if (bodyInfo.hoistedExportsString) {
         codeToInsert += bodyInfo.hoistedExportsString;
@@ -303,7 +304,14 @@ class ImportExportVisitor extends Visitor {
       }
 
       hoistExports(this, path, specifierMap, "declaration");
-      addExportedLocalNames(this, specifierMap);
+
+      if (! isConstExportDeclaration(decl)) {
+        // We can skip adding declared names to this.exportedLocalNames if
+        // the declaration was a const-kinded VariableDeclaration, because
+        // the assignmentVisitor will not need to worry about changes to
+        // these variables.
+        addExportedLocalNames(this, specifierMap);
+      }
 
       return;
     }
@@ -528,6 +536,7 @@ function getBlockBodyInfo(visitor, path) {
     bodyInfo.insertCharIndex = insertCharIndex;
     bodyInfo.insertNodeIndex = insertNodeIndex;
     bodyInfo.hoistedExportsMap = Object.create(null);
+    bodyInfo.hoistedConstExportsMap = Object.create(null);
     bodyInfo.hoistedExportsString = "";
     bodyInfo.hoistedImportsString = "";
 
@@ -575,6 +584,7 @@ function hoistExports(visitor, exportDeclPath, mapOrString, childName) {
   }
 
   const bodyInfo = getBlockBodyInfo(visitor, exportDeclPath);
+  const constant = isConstExportDeclaration(exportDeclPath.getValue());
 
   if (typeof mapOrString !== "string") {
     const keys = Object.keys(mapOrString);
@@ -587,7 +597,9 @@ function hoistExports(visitor, exportDeclPath, mapOrString, childName) {
 
       for (let j = 0; j < localCount; ++j) {
         addToSpecifierMap(
-          bodyInfo.hoistedExportsMap,
+          constant
+            ? bodyInfo.hoistedConstExportsMap
+            : bodyInfo.hoistedExportsMap,
           exported,
           locals[j]
         );
@@ -599,6 +611,25 @@ function hoistExports(visitor, exportDeclPath, mapOrString, childName) {
   }
 
   visitor.madeChanges = true;
+}
+
+function isConstExportDeclaration(exportDecl) {
+  if (exportDecl) {
+    if (exportDecl.type === "ExportDefaultDeclaration") {
+      const dd = exportDecl.declaration;
+      return (dd.type !== "FunctionDeclaration" &&
+              dd.type !== "ClassDeclaration");
+    }
+
+    if (exportDecl.type === "ExportNamedDeclaration") {
+      const dd = exportDecl.declaration;
+      return !! dd &&
+        dd.type === "VariableDeclaration" &&
+        dd.kind === "const";
+    }
+  }
+
+  return false;
 }
 
 function makeUniqueKey(visitor) {
@@ -802,7 +833,7 @@ function toModuleImport(source, specifierMap, uniqueKey) {
   return code;
 }
 
-function toModuleExport(visitor, specifierMap) {
+function toModuleExport(visitor, specifierMap, constant) {
   let code = "";
   const exportedKeys = Object.keys(specifierMap);
   const keyCount = exportedKeys.length;
@@ -834,7 +865,9 @@ function toModuleExport(visitor, specifierMap) {
     }
   }
 
-  code += "});";
+  // The second argument to module.export indicates whether the getter
+  // functions provided in the first argument are constant or not.
+  code += constant ? "},true);" : "});";
 
   return code;
 }

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -8,8 +8,6 @@ const MagicString = require("./magic-string.js");
 const Visitor = require("./visitor.js");
 
 const codeOfCR = "\r".charCodeAt(0);
-const exportDefaultPrefix = 'module.export("default",exports.default=(';
-const exportDefaultSuffix = "));";
 
 class ImportExportVisitor extends Visitor {
   finalizeHoisting() {
@@ -225,15 +223,28 @@ class ImportExportVisitor extends Visitor {
       }, "declaration");
 
     } else {
-      // Otherwise, since the exported value is an expression, it's
-      // important that we wrap it with parentheses, in case it's something
-      // like a comma-separated sequence expression.
-      overwrite(this, decl.start, dd.start, exportDefaultPrefix);
+      // Otherwise, since the exported value is an expression, we use the
+      // special module.exportDefault(value) form.
 
       path.call(this.visitWithoutReset, "declaration");
       assert.strictEqual(decl.declaration, dd);
 
-      overwrite(this, dd.end, decl.end, exportDefaultSuffix, true);
+      let prefix = "module.exportDefault(";
+      let suffix = ");";
+
+      if (dd.type === "SequenceExpression") {
+        // If the exported expression is a comma-separated sequence
+        // expression, this.code.slice(dd.start, dd.end) may not include
+        // the vital parentheses, so we should wrap the expression with
+        // parentheses to make absolutely sure it is treated as a single
+        // argument to the module.exportDefault method, rather than as
+        // multiple arguments.
+        prefix += "(";
+        suffix = ")" + suffix;
+      }
+
+      overwrite(this, decl.start, dd.start, prefix);
+      overwrite(this, dd.end, decl.end, suffix, true);
 
       if (this.modifyAST) {
         // A Function or Class declaration has become an expression on the
@@ -245,7 +256,22 @@ class ImportExportVisitor extends Visitor {
           dd.type = "ClassExpression";
         }
 
-        path.replace(buildExportDefaultStatement(this, dd));
+        // Almost every JS parser parses this expression the same way, but
+        // we should still give custom parsers a chance to parse it.
+        let ast = this.parse("module.exportDefault(ARG);");
+        if (ast.type === "File") ast = ast.program;
+        assert.strictEqual(ast.type, "Program");
+
+        const callExprStmt = ast.body[0];
+        assert.strictEqual(callExprStmt.type, "ExpressionStatement");
+
+        const callExpr = callExprStmt.expression;
+        assert.strictEqual(callExpr.type, "CallExpression");
+
+        // Replace the ARG identifier with the exported expression.
+        callExpr.arguments[1] = dd;
+
+        path.replace(callExprStmt);
       }
 
       this.madeChanges = true;
@@ -358,29 +384,6 @@ function addToSpecifierMap(map, __ported, local) {
   map[__ported] = locals;
 
   return map;
-}
-
-function buildExportDefaultStatement(visitor, declaration) {
-  let ast = visitor.parse(exportDefaultPrefix + "VALUE" + exportDefaultSuffix);
-
-  if (ast.type === "File") {
-    ast = ast.program;
-  }
-
-  assert.strictEqual(ast.type, "Program");
-
-  const stmt = ast.body[0];
-  assert.strictEqual(stmt.type, "ExpressionStatement");
-  assert.strictEqual(stmt.expression.type, "CallExpression");
-
-  const arg1 = stmt.expression.arguments[1];
-  assert.strictEqual(arg1.right.type, "Identifier");
-  assert.strictEqual(arg1.right.name, "VALUE");
-
-  // Replace the VALUE identifier with the desired declaration.
-  arg1.right = declaration;
-
-  return stmt;
 }
 
 // Returns a map from {im,ex}ported identifiers to lists of local variable

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -305,7 +305,7 @@ class ImportExportVisitor extends Visitor {
 
       hoistExports(this, path, specifierMap, "declaration");
 
-      if (! isConstExportDeclaration(decl)) {
+      if (canExportedValuesChange(decl)) {
         // We can skip adding declared names to this.exportedLocalNames if
         // the declaration was a const-kinded VariableDeclaration, because
         // the assignmentVisitor will not need to worry about changes to
@@ -584,7 +584,7 @@ function hoistExports(visitor, exportDeclPath, mapOrString, childName) {
   }
 
   const bodyInfo = getBlockBodyInfo(visitor, exportDeclPath);
-  const constant = isConstExportDeclaration(exportDeclPath.getValue());
+  const constant = ! canExportedValuesChange(exportDeclPath.getValue());
 
   if (typeof mapOrString !== "string") {
     const keys = Object.keys(mapOrString);
@@ -613,23 +613,25 @@ function hoistExports(visitor, exportDeclPath, mapOrString, childName) {
   visitor.madeChanges = true;
 }
 
-function isConstExportDeclaration(exportDecl) {
+function canExportedValuesChange(exportDecl) {
   if (exportDecl) {
     if (exportDecl.type === "ExportDefaultDeclaration") {
       const dd = exportDecl.declaration;
-      return (dd.type !== "FunctionDeclaration" &&
-              dd.type !== "ClassDeclaration");
+      return (dd.type === "FunctionDeclaration" ||
+              dd.type === "ClassDeclaration");
     }
 
     if (exportDecl.type === "ExportNamedDeclaration") {
       const dd = exportDecl.declaration;
-      return !! dd &&
-        dd.type === "VariableDeclaration" &&
-        dd.kind === "const";
+      if (dd &&
+          dd.type === "VariableDeclaration" &&
+          dd.kind === "const") {
+        return false;
+      }
     }
   }
 
-  return false;
+  return true;
 }
 
 function makeUniqueKey(visitor) {

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -13,6 +13,7 @@ exports.enable = function (mod) {
   if (typeof mod.export !== "function" ||
       typeof mod.importSync !== "function") {
     mod.export = moduleExport;
+    mod.exportDefault = moduleExportDefault;
     mod.import = moduleImport;
     mod.runSetters = runSetters;
     mod.watch = watch;
@@ -37,22 +38,27 @@ function importSync(id, setters, key) {
 }
 
 // Register getter functions for local variables in the scope of an export
-// statement. The keys of the getters object are exported names, and the
-// values are functions that return local values.
-function moduleExport(getters) {
+// statement. Pass true as the second argument to indicate that the getter
+// functions always return the same values.
+function moduleExport(getters, constant) {
   utils.setESModule(this.exports);
   var entry = Entry.getOrCreate(this.exports);
-
-  if (utils.isObject(getters)) {
-    entry.addGetters(getters);
-  }
-
+  entry.addGetters(getters, constant);
   if (this.loaded) {
     // If the module has already been evaluated, then we need to trigger
     // another round of entry.runSetters calls, which begins by calling
     // entry.runModuleGetters(module).
     entry.runSetters();
   }
+}
+
+// Register a getter function that always returns the given value.
+function moduleExportDefault(value) {
+  return this.export({
+    default: function () {
+      return value;
+    }
+  }, true);
 }
 
 function moduleImport(id) {

--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -60,7 +60,7 @@ function extWrap(func, pkgInfo, mod, filePath) {
 
   runtime.enable(mod);
   mod._compile(cacheValue, filePath);
-  mod.runModuleSetters();
+  mod.runSetters();
 }
 
 wrapper.manage(exts, ".js", extManager);

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -36,7 +36,7 @@ describe("babel-plugin-transform-es2015-modules-reify", () => {
     const ast = parse(code);
     delete ast.tokens;
     const result = transformFromAst(ast, code, options);
-    assert.ok(/\bmodule\.(?:export|import(?:Sync)?|watch)\b/.test(result.code));
+    assert.ok(/\bmodule\.(?:export(?:Default)?|import(?:Sync)?|watch)\b/.test(result.code));
     return result;
   }
 

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -87,7 +87,7 @@ describe("compiler", () => {
     isVarDecl(ast.body[firstIndex + 2], ["bar"]);
     isCallExprStmt(ast.body[firstIndex + 3], "module", "watch");
     isCallExprStmt(ast.body[firstIndex + 4], "console", "log");
-    isCallExprStmt(ast.body[firstIndex + 5], "module", "export");
+    isCallExprStmt(ast.body[firstIndex + 5], "module", "exportDefault");
   });
 
   it("should respect options.enforceStrictMode", () => {
@@ -252,7 +252,7 @@ describe("compiler", () => {
 
     assert.strictEqual(anonAST.body.length - anonFirstIndex, 1);
     assert.strictEqual(
-      anonAST.body[anonFirstIndex].expression.arguments[1].right.type,
+      anonAST.body[anonFirstIndex].expression.arguments[1].type,
       "ClassExpression"
     );
 

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -109,16 +109,12 @@ describe("export declarations", () => {
     assert.strictEqual(val, "value-1");
 
     exportAgain();
-    assert.strictEqual(def, "default-2");
-    assert.strictEqual(val, "value-2");
-
-    exportYetAgain();
-    assert.strictEqual(def, "default-3");
+    assert.strictEqual(def, "default-1");
     assert.strictEqual(val, "value-2");
 
     setImmediate(() => {
       oneLastExport();
-      assert.strictEqual(def, "default-3");
+      assert.strictEqual(def, "default-1");
       assert.strictEqual(val, "value-3");
       done();
     });

--- a/test/export/later.js
+++ b/test/export/later.js
@@ -4,13 +4,16 @@ export default "default-1";
 export let val = "value-1";
 
 export function exportAgain() {
-  module.export("default", exports.default = "default-2");
+  // Neither of these re-export styles should work, because the original
+  // export default still takes precedence over anything else.
+  module.exportDefault(exports.default = "default-2");
+
+  // This style also does not work, because the getter function for the
+  // variable val is all that matters.
+  exports.val = "ignored";
+
   val = +(val.split("-")[1]);
   val = "value-" + ++val;
-}
-
-export function exportYetAgain() {
-  module.export("default", exports.default = "default-3");
 }
 
 export function oneLastExport() {

--- a/test/output/anon-class/expected.js
+++ b/test/output/anon-class/expected.js
@@ -1,5 +1,5 @@
-"use strict";module.export("default",exports.default=(class {
+"use strict";module.exportDefault(class {
   constructor(value) {
     this.value = value;
   }
-}));
+});

--- a/test/output/declarations-basic/expected.js
+++ b/test/output/declarations-basic/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({a:()=>a,b:()=>b,c:()=>c,d:()=>d});const a = 1;
+"use strict";module.export({c:()=>c,d:()=>d});module.export({a:()=>a,b:()=>b},true);const a = 1;
 const b = function () {
   return d;
 };

--- a/test/output/default-expression/expected.js
+++ b/test/output/default-expression/expected.js
@@ -2,4 +2,4 @@
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.
-module.export("default",exports.default=(count++, count));
+module.exportDefault((count++, count));

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,2 @@
 "use strict";module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
-module.export("default",exports.default=("default"));
+module.exportDefault("default");

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,4 +1,4 @@
-"use strict";module.export({id:()=>id,name:()=>name});const path = require("path");
+"use strict";module.export({id:()=>id,name:()=>name},true);const path = require("path");
 
 const id = module.id,
   name = path.basename(__filename);

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -57,4 +57,41 @@ describe("parent setters", () => {
     assert.strictEqual(secondCallCount, 2);
     assert.strictEqual(value, "second:7");
   });
+
+  it("should only be discarded if getter did not throw", () => {
+    // Manually register setters for value and set, which are marked as
+    // constant in the fake-const.js module, even though they are actually
+    // mutable (see below).
+    let value, set;
+    let valueSetterCallCount = 0;
+    module.watch(require("./setter/fake-const.js"), {
+      value: v => {
+        value = v;
+        valueSetterCallCount += 1;
+      },
+      set: v => set = v
+    });
+
+    // Because the getter for value in fake-const.js throws, the initial
+    // value here is undefined, and our live binding to that value is
+    // maintained for now.
+    assert.strictEqual(value, void 0);
+    assert.strictEqual(valueSetterCallCount, 1);
+
+    // Since the exported value is marked as constant, the setter that
+    // updates our copy of value should be discarded as soon as it has
+    // been called with the final value, but this set(2) still works
+    // because the getter threw the last time it was called. After this,
+    // however, the setter function will be discarded.
+    set(2);
+    assert.strictEqual(value, 2);
+    assert.strictEqual(valueSetterCallCount, 2);
+
+    // Because the exported value is marked as constant, this set(3) is
+    // not reflected in this scope, because the setter that we registered
+    // above has been thrown away.
+    set(3);
+    assert.strictEqual(value, 2);
+    assert.strictEqual(valueSetterCallCount, 2);
+  });
 });

--- a/test/setter/fake-const.js
+++ b/test/setter/fake-const.js
@@ -1,0 +1,18 @@
+// Throw once for the mod.runSetters() call in reify/node/compile-hook.js,
+// and again for the first time we call module.runSetters in set below.
+let throwTimes = 2;
+let value = 1;
+
+module.export({
+  value: () => {
+    if (throwTimes-- > 0) {
+      throw new Error("simulated");
+    }
+    return value;
+  },
+  set: () => set
+}, true); // Mark as constant.
+
+function set(to) {
+  return module.runSetters(value = to);
+}

--- a/test/setter/fake-const.js
+++ b/test/setter/fake-const.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Throw once for the mod.runSetters() call in reify/node/compile-hook.js,
 // and again for the first time we call module.runSetters in set below.
 let throwTimes = 2;

--- a/test/setter/grandchild.js
+++ b/test/setter/grandchild.js
@@ -1,5 +1,5 @@
 export let c = 0;
 export function increment() {
   ++c;
-  module.export();
+  module.runSetters();
 };


### PR DESCRIPTION
This pull request
* compiles `export default <expr>` to `module.exportDefault(<expr>)` instead of `module.export("default", exports.default = <expr>)`, which means `module.export` no longer has to handle completely different argument types;
* signals when the values returned by getter functions will never change by calling `module.export(getters, true)`; and
* discards setter functions that will never be called again, fixing #134.