### PR TITLE
#167 safe use of reserved keyword `import` as IdentifierName

### DIFF
--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -19,7 +19,7 @@ exports.enable = function (mod) {
       typeof mod.importSync !== "function") {
     mod.export = moduleExport;
     mod.exportDefault = moduleExportDefault;
-    mod.import = moduleImport;
+    mod["import"] = moduleImport;
     mod.run = moduleRun;
     mod.runSetters = runSetters;
     mod.watch = watch;

--- a/node/runtime.js
+++ b/node/runtime.js
@@ -5,7 +5,7 @@ const utils = require("./utils.js");
 
 exports.enable = function (mod) {
   if (runtime.enable(mod)) {
-    mod.import = wrapImport(mod.import);
+    mod["import"] = wrapImport(mod["import"]);
     mod.importSync = wrapImportSync(mod.importSync);
     return true;
   }


### PR DESCRIPTION
A possible fix for #167 although I am not sure how to verify this locally.