### PR TITLE
Add failing test due to missing module.runSetters() call.

### DIFF
--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -57,6 +57,11 @@ function extWrap(func, pkgInfo, mod, filePath) {
 
   runtime.enable(mod);
   mod._compile(cacheValue, filePath);
+
+  // If the module is not loaded through module.run, then run its setters.
+  if (! mod.loaded) {
+    mod.runSetters();
+  }
 }
 
 wrapper.manage(exts, ".js", extManager);

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -9,6 +9,13 @@ describe("module.runSetters", () => {
     assert.strictEqual(value, result);
     assert.strictEqual(value, "modified");
   });
+
+  it("should be called for untouched CJS modules, too", () => {
+    // Import the CommonJS module first, but do not register any setters.
+    import "./setter/cycle/cjs.js";
+    import { getSum } from "./setter/cycle/esm.js";
+    assert.strictEqual(getSum(), 3);
+  });
 });
 
 describe("parent setters", () => {

--- a/test/setter/cycle/cjs.js
+++ b/test/setter/cycle/cjs.js
@@ -1,0 +1,3 @@
+exports.one = 1;
+require("./esm.js");
+exports.two = 2;

--- a/test/setter/cycle/esm.js
+++ b/test/setter/cycle/esm.js
@@ -1,0 +1,5 @@
+import { one, two } from "./cjs.js";
+
+export function getSum() {
+  return one + two;
+}


### PR DESCRIPTION
This test fails because module.runSetters() is not called when the `test/setter/cycle/cjs.js` module finishes evaluating, due to this commit: 7932aa56cef2ead61084c3b67a5afa329fe5415e

The general problem is that we need to call `module.runSetters()` even for modules that were not compiled by Reify, or wrapped with `module.run(...)`, so that other modules can import live bindings from them.

If you add `module.runSetters()` to the end of cjs.js, or add back the `module.runSetters()` call in the compile hook, this test will pass.