### PR TITLE
Pass namespaces to module.watch so child module can manage them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import * as utils from "./utils";
 ```
 becomes
 ```js
-const utils = module.createNs();
+const utils = Object.create(null);
 module.watch(require("./utils"), {
   "*": (value, name) => {
     utils[name] = value;

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -143,11 +143,11 @@ class ImportExportVisitor extends Visitor {
   visitImportDeclaration(path) {
     const decl = path.getValue();
     const specifierCount = decl.specifiers.length;
+    const namespaces = [];
     let hoistedCode = "";
 
     if (specifierCount) {
       const identifiers = [];
-      const namespaces = [];
 
       for (let i = 0; i < specifierCount; ++i) {
         const s = decl.specifiers[i];
@@ -182,7 +182,7 @@ class ImportExportVisitor extends Visitor {
           const isLast = i === lastIndex;
           hoistedCode +=
             namespaces[i] +
-            "=" + this.moduleAlias + ".createNs()" +
+            "=Object.create(null)" +
             (isLast ? ";" : ",");
         }
       }
@@ -191,7 +191,8 @@ class ImportExportVisitor extends Visitor {
     hoistedCode += toModuleImport(
       this,
       getSourceString(this, decl),
-      computeSpecifierMap(decl.specifiers)
+      computeSpecifierMap(decl.specifiers),
+      namespaces
     );
 
     hoistImports(this, path, hoistedCode);
@@ -344,12 +345,16 @@ class ImportExportVisitor extends Visitor {
           specifierMap = newMap;
         }
 
-        // Even though the compiled code uses module.importSync, it should
+        // Even though the compiled code uses module.watch, it should
         // still be hoisted as an export, i.e. before actual imports.
         hoistExports(this, path, toModuleImport(
           this,
           getSourceString(this, decl),
-          specifierMap
+          specifierMap,
+          // This array of namespace identifiers can be empty, because
+          // toModuleImport automatically includes any export.ns
+          // expressions from ExportNamespaceSpecifier nodes.
+          []
         ));
 
       } else {
@@ -778,7 +783,7 @@ function safeParam(param, locals) {
   return safeParam("_" + param, locals);
 }
 
-function toModuleImport(visitor, source, specifierMap) {
+function toModuleImport(visitor, source, specifierMap, namespaces) {
   let code = visitor.moduleAlias + ".watch(require(" + source + ")";
   const importedNames = Object.keys(specifierMap);
   const nameCount = importedNames.length;
@@ -809,10 +814,8 @@ function toModuleImport(visitor, source, specifierMap) {
       const local = locals[0];
 
       if (local.startsWith("exports.")) {
-        code =
-          local + "=" +
-          visitor.moduleAlias + ".createNs();" +
-          code;
+        code = local + "=Object.create(null);" + code;
+        namespaces.push(local);
       }
       // When the imported name is "*", the setter function may be called
       // multiple times, and receives an additional parameter specifying
@@ -837,7 +840,13 @@ function toModuleImport(visitor, source, specifierMap) {
     }
   }
 
-  code += "}," + makeUniqueKey(visitor) + ");";
+  code += "}," + makeUniqueKey(visitor);
+
+  if (namespaces.length > 0) {
+    code += ",[" + namespaces.join(",") + "]";
+  }
+
+  code += ");";
 
   return code;
 }

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -21,9 +21,11 @@ var entryKey = useSymbol ? entrySymKey : entryStrKey;
 var hasOwn = Object.prototype.hasOwnProperty;
 var keySalt = 0;
 
-function Entry(exported) {
+function Entry(exported, owner) {
   // The module.exports of the module this Entry is managing.
   this.exports = exported;
+  // The module object this Entry is managing, if known.
+  this.owner = owner || null;
   // Getters for local variables exported from the managed module.
   this.getters = Object.create(null);
   // Namespace objects created in the managed module.
@@ -47,20 +49,20 @@ function get(exported) {
 
 Entry.get = get;
 
-function getOrCreate(exported) {
+function getOrCreate(exported, owner) {
   if (! utils.isObjectLike(exported)) {
     // In case the child module modified module.exports, create a temporary
     // Entry object so that we can call the entry.addSetters method once,
     // which will trigger entry.runSetters(names), so that module.importSync
     // behaves as expected.
-    return new Entry(exported);
+    return new Entry(exported, owner);
   }
 
   if (hasOwn.call(exported, entryKey)) {
     return exported[entryKey];
   }
 
-  var entry = new Entry(exported);
+  var entry = new Entry(exported, owner);
 
   if (useSymbol) {
     exported[entryKey] = entry;

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -153,7 +153,7 @@ function addSetters(parent, setters, key, namespaces) {
 
   this.runSetters(names);
 
-  if (utils.isArray(namespaces)) {
+  if (Array.isArray(namespaces)) {
     // If any namespace objects were provided, remember them so that we
     // can call Object.seal(namespace) later, when the module this Entry
     // is managing has finished loading.

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -12,6 +12,7 @@ var NAN = {};
 var UNDEFINED = {};
 
 var useSymbol = typeof Symbol === "function";
+var useToStringTag = useSymbol && typeof Symbol.toStringTag === "symbol";
 
 var entryStrKey = "__reifyEntry";
 var entrySymKey = useSymbol ? Symbol.for(entryStrKey) : null;
@@ -29,6 +30,9 @@ function Entry(exported) {
   this.nsObjects = [];
   // Setters for assigning to local variables in parent modules.
   this.setters = Object.create(null);
+  // Boolean indicating whether the module this Entry is managing has
+  // finished evaluation yet.
+  this.loaded = false;
 }
 
 var Ep = utils.setPrototypeOf(Entry.prototype, null);
@@ -97,13 +101,26 @@ function addGetters(getters, constant) {
 
 Ep.addGetters = addGetters;
 
-function addNs(ns) {
-  this.nsObjects.push(ns);
+function addNamespace(ns) {
+  if (useToStringTag) {
+    Object.defineProperty(ns, Symbol.toStringTag, {
+      value: "Module",
+      configurable: false,
+      enumerable: false,
+      writable: false
+    });
+  }
+
+  if (this.loaded) {
+    Object.seal(ns);
+  } else {
+    this.nsObjects.push(ns);
+  }
 }
 
-Ep.addNs = addNs;
+Ep.addNamespace = addNamespace;
 
-function addSetters(parent, setters, key) {
+function addSetters(parent, setters, key, namespaces) {
   var names = Object.keys(setters);
   var nameCount = names.length;
 
@@ -133,6 +150,16 @@ function addSetters(parent, setters, key) {
   }
 
   this.runSetters(names);
+
+  if (utils.isArray(namespaces)) {
+    // If any namespace objects were provided, remember them so that we
+    // can call Object.seal(namespace) later, when the module this Entry
+    // is managing has finished loading.
+    var nsCount = namespaces.length;
+    for (var i = 0; i < nsCount; ++i) {
+      this.addNamespace(namespaces[i]);
+    }
+  }
 }
 
 Ep.addSetters = addSetters;
@@ -214,6 +241,15 @@ function runSetters(names) {
 }
 
 Ep.runSetters = runSetters;
+
+// Called by module.runSetters once the module this Entry is managing has
+// finished loading.
+Ep.onLoaded = function () {
+  if (! this.loaded) {
+    this.loaded = true;
+    this.nsObjects.forEach(Object.seal);
+  }
+};
 
 function call(setter, name, value, callback) {
   if (name === "__esModule") {

--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -8,9 +8,6 @@
 var utils = require("./utils.js");
 var Entry = require("./entry.js");
 
-var useSymbol = typeof Symbol === "function";
-var useToStringTag = useSymbol && typeof Symbol.toStringTag === "symbol";
-
 function Runtime() {}
 var Rp = utils.setPrototypeOf(Runtime.prototype, null);
 
@@ -31,24 +28,6 @@ function enable(mod) {
 }
 
 Runtime.enable = enable;
-
-function createNs() {
-  var ns = Object.create(null);
-
-  if (useToStringTag) {
-    Object.defineProperty(ns, Symbol.toStringTag, {
-      configurable: false,
-      enumerable: false,
-      value: "Module",
-      writable: false
-    });
-  }
-
-  Entry.getOrCreate(this.exports).addNs(ns);
-  return ns;
-}
-
-Rp.createNs = createNs;
 
 // Register getter functions for local variables in the scope of an export
 // statement. Pass true as the second argument to indicate that the getter
@@ -84,13 +63,15 @@ function moduleImport(id) {
   var that = this;
 
   return Promise.resolve().then(function () {
-    var ns = that.createNs();
+    var ns = Object.create(null);
+
     that.watch(that.require(id), {
       "*": function (value, name) {
         ns[name] = value;
       }
-    });
-    return finishNs(ns);
+    }, void 0, [ns]);
+
+    return ns;
   });
 }
 
@@ -101,8 +82,8 @@ Rp.import = moduleImport;
 // same key. This avoids potential memory leaks from import declarations
 // inside loops. The compiler generates these keys automatically (and
 // deterministically) when compiling nested import declarations.
-function moduleImportSync(id, setters, key) {
-  return this.watch(this.require(id), setters, key);
+function moduleImportSync(id, setters, key, namespaces) {
+  return this.watch(this.require(id), setters, key, namespaces);
 }
 
 Rp.importSync = moduleImportSync;
@@ -111,16 +92,6 @@ function run(wrapper) {
   wrapper();
   this.loaded = true;
   this.runSetters();
-
-  var entry = Entry.get(this.exports);
-  if (entry !== null) {
-    var nsObjects = entry.nsObjects;
-    var nsCount = nsObjects.length;
-
-    for (var i = 0; i < nsCount; ++i) {
-      finishNs(nsObjects[i]);
-    }
-  }
 }
 
 Rp.run = run;
@@ -132,7 +103,22 @@ Rp.run = run;
 function runSetters(valueToPassThrough) {
   var entry = Entry.get(this.exports);
   if (entry !== null) {
+    // If there's not already an Entry object for this module, then there
+    // won't be any setters to run.
     entry.runSetters();
+  }
+
+  if (this.loaded) {
+    // If this module has already loaded, then we have to create an Entry
+    // object here, so that we can call entry.onLoaded(), which sets
+    // entry.loaded true for any future modules that might want to import
+    // from this module. If we don't create the Entry now, we'll never
+    // have another chance to call entry.onLoaded().
+    if (entry === null) {
+      entry = Entry.getOrCreate(this.exports);
+    }
+
+    entry.onLoaded();
   }
 
   // Assignments to exported local variables get wrapped with calls to
@@ -157,11 +143,12 @@ function runSetters(valueToPassThrough) {
 Rp.runSetters =
 Rp.runModuleSetters = runSetters;
 
-function watch(exported, setters, key) {
+function watch(exported, setters, key, namespaces) {
   utils.setESModule(this.exports);
 
   if (utils.isObject(setters)) {
-    Entry.getOrCreate(exported).addSetters(this, setters, key);
+    Entry.getOrCreate(exported)
+      .addSetters(this, setters, key, namespaces);
   }
 }
 

--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -33,9 +33,9 @@ Runtime.enable = enable;
 // statement. Pass true as the second argument to indicate that the getter
 // functions always return the same values.
 function moduleExport(getters, constant) {
-  utils.setESModule(this.exports);
+  setESModuleAndOwner(this);
 
-  var entry = Entry.getOrCreate(this.exports);
+  var entry = Entry.getOrCreate(this.exports, this);
   entry.addGetters(getters, constant);
 
   if (this.loaded) {
@@ -89,6 +89,7 @@ function moduleImportSync(id, setters, key, namespaces) {
 Rp.importSync = moduleImportSync;
 
 function run(wrapper) {
+  setESModuleAndOwner(this);
   wrapper();
   this.loaded = true;
   this.runSetters();
@@ -115,10 +116,20 @@ function runSetters(valueToPassThrough) {
     // from this module. If we don't create the Entry now, we'll never
     // have another chance to call entry.onLoaded().
     if (entry === null) {
-      entry = Entry.getOrCreate(this.exports);
+      entry = Entry.getOrCreate(this.exports, this);
     }
 
-    entry.onLoaded();
+    // Multiple modules can share the same Entry object because they share
+    // the same module.exports object, e.g. when a "bridge" module sets
+    // module.exports = require(...) to make itself roughly synonymous
+    // with some other module. Just because the bridge module has finished
+    // loading (as far as it's concerned), that doesn't mean it should
+    // control the loading state of the (possibly shared) Entry. Long
+    // story short: we should only call entry.onLoaded() if this module is
+    // the owner of this Entry object.
+    if (entry.owner === this) {
+      entry.onLoaded();
+    }
   }
 
   // Assignments to exported local variables get wrapped with calls to
@@ -144,7 +155,7 @@ Rp.runSetters =
 Rp.runModuleSetters = runSetters;
 
 function watch(exported, setters, key, namespaces) {
-  utils.setESModule(this.exports);
+  setESModuleAndOwner(this);
 
   if (utils.isObject(setters)) {
     Entry.getOrCreate(exported)
@@ -154,8 +165,9 @@ function watch(exported, setters, key, namespaces) {
 
 Rp.watch = watch;
 
-function finishNs(ns) {
-  return Object.seal(ns);
+function setESModuleAndOwner(module) {
+  utils.setESModule(module.exports);
+  Entry.getOrCreate(module.exports, module);
 }
 
 module.exports = Runtime;

--- a/lib/runtime/utils.js
+++ b/lib/runtime/utils.js
@@ -12,6 +12,7 @@ var esStrKey = "__esModule";
 var esSymKey = useSymbol ? Symbol.for(esStrKey) : null;
 
 var hasOwn = Object.prototype.hasOwnProperty;
+var objToStr = Object.prototype.toString;
 
 function getESModule(exported) {
   if (isObjectLike(exported)) {
@@ -41,6 +42,12 @@ function isObjectLike(value) {
 }
 
 exports.isObjectLike = isObjectLike;
+
+function isArray(value) {
+  return objToStr.call(value) === "[object Array]";
+}
+
+exports.isArray = isArray;
 
 function setESModule(exported) {
   if (isObjectLike(exported)) {

--- a/lib/runtime/utils.js
+++ b/lib/runtime/utils.js
@@ -43,12 +43,6 @@ function isObjectLike(value) {
 
 exports.isObjectLike = isObjectLike;
 
-function isArray(value) {
-  return objToStr.call(value) === "[object Array]";
-}
-
-exports.isArray = isArray;
-
 function setESModule(exported) {
   if (isObjectLike(exported)) {
     if (useSymbol) {

--- a/node/compile-hook.js
+++ b/node/compile-hook.js
@@ -60,6 +60,7 @@ function extWrap(func, pkgInfo, mod, filePath) {
 
   // If the module is not loaded through module.run, then run its setters.
   if (! mod.loaded) {
+    mod.loaded = true;
     mod.runSetters();
   }
 }

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=module.createNs();module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0);
+module.run(function(){"use strict";module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0,[n]);
 
 
 

--- a/test/output/mixed-keys/expected.js
+++ b/test/output/mixed-keys/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=module.createNs();module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1);
+module.run(function(){"use strict";var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1,[$2]);
 
 
 })

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -1,4 +1,5 @@
-const assert = require("assert");
+import assert from "assert";
+import { join as pathJoin } from "path";
 
 describe("module.runSetters", () => {
   it("should be called after eval(...)", () => {
@@ -15,6 +16,19 @@ describe("module.runSetters", () => {
     import "./setter/cycle/cjs.js";
     import { getSum } from "./setter/cycle/esm.js";
     assert.strictEqual(getSum(), 3);
+  });
+});
+
+describe("bridge modules", () => {
+  it("should not prematurely seal * exports", () => {
+    import { bridge } from "./setter/cycle/bridge-owner.js";
+
+    assert.strictEqual(
+      bridge.name,
+      pathJoin(__dirname, "setter/cycle/bridge-owner.js")
+    );
+
+    assert.strictEqual(bridge, bridge.bridge);
   });
 });
 

--- a/test/setter/cycle/bridge-owner.js
+++ b/test/setter/cycle/bridge-owner.js
@@ -1,0 +1,2 @@
+export * as bridge from "./bridge.js";
+exports.name = module.id;

--- a/test/setter/cycle/bridge.js
+++ b/test/setter/cycle/bridge.js
@@ -1,0 +1,1 @@
+module.exports = require("./bridge-owner.js");


### PR DESCRIPTION
Fixes #171.

With these changes, an `import` declaration like
```js
import * as ns from "./child";
```
gets transformed to
```js
const ns = Object.create(null);
module.watch(require("./child"), {
  "*": (value, name) => {
    ns[name] = value;
  }
}, key, [ns]);
```
and an `export` declaration like
```js
export * as ns from "./child";
```
gets transformed to
```js
exports.ns = Object.create(null);
module.watch(require("./child"), {
  "*": (value, name) => {
    exports.ns[name] = value;
  }
}, key, [exports.ns]);
```
The `module.watch` API is now responsible for setting up the namespace object and remembering it until it can be sealed, because no new properties need to be added.