### PR TITLE
Add support for specifying multiple namespace exports in a clause.

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -26,27 +26,16 @@ class ImportExportVisitor extends Visitor {
 
       if (bodyInfo.parent.type === "Program" &&
           this.moduleAlias !== "module") {
-        codeToInsert += this.generateLetDeclarations ? "const " : "var ";
-        codeToInsert += this.moduleAlias + "=module;";
+        codeToInsert +=
+          (this.generateLetDeclarations ? "const " : "var ") +
+          this.moduleAlias + "=module;";
       }
 
-      const addExportsMap = (map, constant) => {
-        const namedExports = toModuleExport(this, map, constant);
-        if (namedExports) {
-          codeToInsert += namedExports;
-        }
-      };
-
-      addExportsMap(bodyInfo.hoistedExportsMap, false);
-      addExportsMap(bodyInfo.hoistedConstExportsMap, true);
-
-      if (bodyInfo.hoistedExportsString) {
-        codeToInsert += bodyInfo.hoistedExportsString;
-      }
-
-      if (bodyInfo.hoistedImportsString) {
-        codeToInsert += bodyInfo.hoistedImportsString;
-      }
+      codeToInsert +=
+        toModuleExport(this, bodyInfo.hoistedExportsMap, false) +
+        toModuleExport(this, bodyInfo.hoistedConstExportsMap, true) +
+        bodyInfo.hoistedExportsString +
+        bodyInfo.hoistedImportsString;
 
       if (codeToInsert) {
         if (this.magicString !== null) {
@@ -350,11 +339,7 @@ class ImportExportVisitor extends Visitor {
         hoistExports(this, path, toModuleImport(
           this,
           getSourceString(this, decl),
-          specifierMap,
-          // This array of namespace identifiers can be empty, because
-          // toModuleImport automatically includes any export.ns
-          // expressions from ExportNamespaceSpecifier nodes.
-          []
+          specifierMap
         ));
 
       } else {
@@ -794,12 +779,17 @@ function toModuleImport(visitor, source, specifierMap, namespaces) {
   }
 
   const lastIndex = nameCount - 1;
+  let namespaceList = Array.isArray(namespaces) ? namespaces.join(",") : "";
+  const searchExports = ! namespaceList;
+
   code += ",{";
 
   for (let i = 0; i < nameCount; ++i) {
     const imported = importedNames[i];
     const isLast = i === lastIndex;
     const locals = specifierMap[imported];
+    const localCount = locals.length;
+    const localLastIndex = localCount - 1;
     const valueParam = safeParam("v", locals);
 
     // Generate plain functions, instead of arrow functions, to avoid a perf
@@ -809,25 +799,24 @@ function toModuleImport(visitor, source, specifierMap, namespaces) {
       ":function(" + valueParam;
 
     if (imported === "*") {
-      // There can be only one namespace import/export specifier.
-      assert.strictEqual(locals.length, 1);
-      const local = locals[0];
-
-      if (local.startsWith("exports.")) {
-        code = local + "=Object.create(null);" + code;
-        namespaces.push(local);
-      }
       // When the imported name is "*", the setter function may be called
       // multiple times, and receives an additional parameter specifying
       // the name of the property to be set.
-      const nameParam = safeParam("n", [local, valueParam]);
+      const nameParam = safeParam("n", locals);
+      code += "," + nameParam + "){";
 
-      code +=
-        "," + nameParam + "){" +
+      for (let j = 0; j < localCount; ++j) {
+        const local = locals[j];
+
+        if (searchExports && local.startsWith("exports.")) {
+          code = locals[localLastIndex - j] + "=Object.create(null);" + code;
+          namespaceList += (namespaceList ? "," : "") + local;
+        }
         // The local variable should have been initialized as an empty
         // object when the variable was declared.
-        local + "[" + nameParam + "]=" + valueParam;
-
+        code += local + "[" + nameParam + "]=";
+      }
+      code += valueParam;
     } else {
       // Multiple local variables become a compound assignment.
       code += "){" + locals.join("=") + "=" + valueParam;
@@ -842,8 +831,8 @@ function toModuleImport(visitor, source, specifierMap, namespaces) {
 
   code += "}," + makeUniqueKey(visitor);
 
-  if (namespaces.length > 0) {
-    code += ",[" + namespaces.join(",") + "]";
+  if (namespaceList) {
+    code += ",[" + namespaceList + "]";
   }
 
   code += ");";

--- a/test/babel-plugin-tests.js
+++ b/test/babel-plugin-tests.js
@@ -21,7 +21,8 @@ Object.keys(files).forEach((absPath) => {
       relPath === "export-tests.js" ||
       relPath === "import/extensions.js" ||
       relPath === "import-tests.js" ||
-      relPath === "setter-tests.js") {
+      relPath === "setter-tests.js" ||
+      relPath.startsWith("output/export-multi-namespace/")) {
     return;
   }
 

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -271,8 +271,8 @@ describe("export declarations", () => {
   (canUseExportExtensions ? it : xit)(
   "should support export extensions", () => {
     import {
-      def1, def2, def3, def4,
-      ns1, ns2, ns3, ns4,
+      def1, def2, def3, def4, def5,
+      ns1, ns2, ns3, ns4, ns5,
       a, b, c, d, e
     } from "./export/extensions";
 
@@ -284,20 +284,22 @@ describe("export declarations", () => {
       c as _e,
     } from "./misc/abc";
 
-    assert.strictEqual(def, def1);
-    assert.strictEqual(def, def2);
-    assert.strictEqual(def, def3);
-    assert.strictEqual(def, def4);
+    const defs = [
+      def1, def2, def3, def4, def5
+    ];
 
-    function checkNS(ns) {
+    const namespaces = [
+      ns1, ns2, ns3, ns4, ns5
+    ];
+
+    defs.forEach((d) => {
+      assert.strictEqual(d, def);
+    });
+
+    namespaces.forEach((ns) => {
       assert.deepEqual(ns, def);
       assert.notStrictEqual(ns, def);
-    }
-
-    checkNS(ns1);
-    checkNS(ns2);
-    checkNS(ns3);
-    checkNS(ns4);
+    });
 
     assert.strictEqual(a, _a);
     assert.strictEqual(b, _b);

--- a/test/export/extensions.js
+++ b/test/export/extensions.js
@@ -3,4 +3,4 @@ export { a, b as c }, * as ns2 from "../misc/abc";
 export def1 from "../misc/abc";
 export def2, { b, c as d } from "../misc/abc";
 export def3, * as ns3 from "../misc/abc";
-export * as ns4, { c as e }, def4 from "../misc/abc";
+export * as ns4, * as ns5, { c as e }, def4, def5 from "../misc/abc";

--- a/test/output-tests.js
+++ b/test/output-tests.js
@@ -27,7 +27,10 @@ Object.keys(files).forEach((absPath) => {
 
 describe("output", () => {
   function check(data) {
-    const code = compile(data.actual).code;
+    const code = compile(data.actual, {
+      parse: require("../lib/parsers/acorn.js").parse
+    }).code;
+
     // Consolidate semicolons, then trim blank lines and trailing whitespace.
     const actual = code.replace(/;{2,}/g, ";").replace(/^ +$/gm, "").trimRight();
     const expected = data.expected.trimRight();

--- a/test/output/export-multi-namespace/actual.js
+++ b/test/output/export-multi-namespace/actual.js
@@ -1,0 +1,1 @@
+export * as a, * as b from "module";

--- a/test/output/export-multi-namespace/expected.js
+++ b/test/output/export-multi-namespace/expected.js
@@ -1,0 +1,3 @@
+module.run(function(){"use strict";var module1=module;exports.a=Object.create(null);exports.b=Object.create(null);module1.watch(require("module"),{"*":function(v,n){exports.a[n]=exports.b[n]=v}},0,[exports.a,exports.b]);
+
+})

--- a/test/transform-tests.js
+++ b/test/transform-tests.js
@@ -40,7 +40,8 @@ describe("compiler.transform", () => {
       parse: require("../lib/parsers/babylon.js").parse,
       reject: (relPath) => {
         return relPath === "export/extensions.js" ||
-               relPath === "import/extensions.js";
+               relPath === "import/extensions.js" ||
+               relPath.startsWith("output/export-multi-namespace/");
       }
     });
   }).timeout(5000);


### PR DESCRIPTION
Per our discussion this PR removes the restriction on export clauses so that more than 1 namespace export is allowed.
```js
export * as a, * as b from "./child"
```