### PR TITLE
Further harden REPL detect by checking module.children.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   1. to make (something abstract) more concrete or real<br>
      _"these instincts are, in humans, reified as verbal constructs"_
   2. to regard or treat (an idea, concept, etc.) as if having material existence
-  3. **to enable [ECMAScript 2015 modules](http://www.2ality.com/2014/09/es6-modules-final.html) in *any* version of [Node.js](https://nodejs.org)**
+  3. **to enable [ECMAScript 2015 modules](http://www.2ality.com/2014/09/es6-modules-final.html) (ESM) in *any* version of [Node.js](https://nodejs.org)**
 
 Usage
 ---
@@ -16,7 +16,7 @@ Usage
   2. Call `require("reify")` before importing modules that contain `import`
      and `export` declarations.
 
-You can also easily `reify` the Node REPL:
+Enable ESM in the Node REPL by loading `reify` upon entering:
 
 ```sh
 % node

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = Object.assign(Object.create(null),
+  typeof process === "object" && process !== null &&
+  typeof process.env === "object" && process.env !== null &&
+  process.env
+);

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -1,18 +1,14 @@
 "use strict";
 
+const env = require("../env.js");
 const dynRequire = module.require ? module.require.bind(module) : __non_webpack_require__;
 
-const REIFY_PARSER =
-  typeof process === "object" && process !== null &&
-  typeof process.env === "object" && process.env !== null &&
-  process.env.REIFY_PARSER;
-
-if (REIFY_PARSER === "acorn" ||
-    REIFY_PARSER === "babylon" ||
-    REIFY_PARSER === "top-level") {
-  exports.parse = require("./" + process.env.REIFY_PARSER + ".js").parse;
+if (env.REIFY_PARSER === "acorn" ||
+    env.REIFY_PARSER === "babylon" ||
+    env.REIFY_PARSER === "top-level") {
+  exports.parse = require("./" + env.REIFY_PARSER + ".js").parse;
 } else try {
-  exports.parse = dynRequire(REIFY_PARSER);
+  exports.parse = dynRequire(env.REIFY_PARSER);
 } catch (e) {
   exports.parse = dynRequire("./acorn.js").parse;
 }

--- a/node/repl-hook.js
+++ b/node/repl-hook.js
@@ -4,11 +4,14 @@ const utils = require("./utils.js");
 
 const dynModule = module.parent ? module : __non_webpack_module__;
 const rootModule = utils.getRootModule(dynModule);
+const isREPL = utils.isREPL(rootModule);
+const pkgId = process.env.REIFY_ID || "reify";
+const pkgMain = isREPL ? utils.resolvePath(pkgId, rootModule) : "";
 
-if (utils.isREPL(rootModule)) {
+if (isREPL && rootModule.children.some((mod) => mod.filename === pkgMain)) {
   // Enable import and export statements in the default Node REPL.
-  // Custom REPLs can still define their own eval functions that circumvent this
-  // compilation step, but that's a feature, not a drawback.
+  // Custom REPLs can still define their own eval functions that circumvent
+  // this compilation step, but that's a feature, not a drawback.
   const compile = require("./caching-compiler.js").compile;
   const runtime = require("./runtime.js");
   const vm = require("vm");

--- a/node/repl-hook.js
+++ b/node/repl-hook.js
@@ -1,12 +1,13 @@
 "use strict";
 
+const env = require("../lib/env.js");
 const utils = require("./utils.js");
 
 const dynModule = module.parent ? module : __non_webpack_module__;
 const rootModule = utils.getRootModule(dynModule);
 const isREPL = utils.isREPL(rootModule);
-const pkgId = process.env.REIFY_ID || "reify";
-const pkgMain = isREPL ? utils.resolvePath(pkgId, rootModule) : "";
+const pkgName = env.REIFY_NAME || "reify";
+const pkgMain = isREPL ? utils.resolvePath(pkgName, rootModule) : "";
 
 if (isREPL && rootModule.children.some((mod) => mod.filename === pkgMain)) {
   // Enable import and export statements in the default Node REPL.

--- a/node/repl-hook.js
+++ b/node/repl-hook.js
@@ -10,9 +10,9 @@ const pkgName = env.REIFY_NAME || "reify";
 const pkgMain = isREPL ? utils.resolvePath(pkgName, rootModule) : "";
 
 if (isREPL && rootModule.children.some((mod) => mod.filename === pkgMain)) {
-  // Enable import and export statements in the default Node REPL.
-  // Custom REPLs can still define their own eval functions that circumvent
-  // this compilation step, but that's a feature, not a drawback.
+  // Enable ESM in the default Node REPL by loading `reify` upon entering.
+  // Custom REPLs can still define their own eval functions to bypass this,
+  // but that's a feature, not a drawback.
   const compile = require("./caching-compiler.js").compile;
   const runtime = require("./runtime.js");
   const vm = require("vm");

--- a/node/utils.js
+++ b/node/utils.js
@@ -89,11 +89,10 @@ function getRootModule(mod) {
 exports.getRootModule = getRootModule;
 
 function isREPL(mod) {
-  const root = getRootModule(mod);
-  if (root.filename === null &&
-      root.id === "<repl>" &&
-      root.loaded === false &&
-      root.parent === void 0) {
+  if (mod.filename === null &&
+      mod.id === "<repl>" &&
+      mod.loaded === false &&
+      mod.parent === void 0) {
     return true;
   }
   return false;

--- a/node/version.js
+++ b/node/version.js
@@ -1,10 +1,11 @@
 "use strict";
 
+const env = require("../lib/env.js");
 const fs = require("./fs.js");
 const path = require("path");
 const pkgPath = path.join(__dirname, "../package.json");
 const SemVer = require("semver");
 
 module.exports = new SemVer(
-  process.env.REIFY_VERSION || fs.readJSON(pkgPath).version
+  env.REIFY_VERSION || fs.readJSON(pkgPath).version
 );

--- a/test/repl-tests.js
+++ b/test/repl-tests.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 
 // Masquerade as the REPL module.
+module.children = [require.cache[require.resolve("reify")]];
 module.filename = null;
 module.id = "<repl>";
 module.loaded = false;


### PR DESCRIPTION
This takes the check a bit further and only enables the wrapper if reify was explicitly required from the REPL.