### PR TITLE
Move module.run wrapper to compile-hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ module.watch(require("./module"), {
   // The keys of this object literal are the names of exported symbols.
   // The values are setter functions that take new values and update the
   // local variables.
-  default: value => { a = value; },
-  b: value => { b = value; },
-  c: value => { d = value; },
+  default(value) { a = value; },
+  b(value) { b = value; },
+  c(value) { d = value; },
 });
 ```
 
@@ -86,7 +86,7 @@ becomes
 ```js
 const utils = Object.create(null);
 module.watch(require("./utils"), {
-  "*": (value, name) => {
+  ["*"](value, name) {
     utils[name] = value;
   }
 });
@@ -113,7 +113,7 @@ becomes
 if (condition) {
   let b;
   module.watch(require("./c"), {
-    a: value => { b = value; }
+    a(value) { b = value; }
   });
   console.log(b);
 }
@@ -170,7 +170,9 @@ export { c as see }
 becomes
 
 ```js
-module.export({ see: () => c });
+module.export({
+  see: () => c
+});
 let c = 123;
 ```
 
@@ -203,9 +205,7 @@ around `module.export`:
 ```js
 module.exportDefault = function (value) {
   return this.export({
-    default: function () {
-      return value;
-    }
+    default: () => value
   }, true);
 };
 ```
@@ -287,8 +287,8 @@ export { a, b as c } from "./module";
 becomes
 ```js
 module.watch(require("./module"), {
-  a: value => { exports.a = value; },
-  b: value => { exports.c = value; },
+  a(value) { exports.a = value; },
+  b(value) { exports.c = value; },
 });
 ```
 
@@ -300,7 +300,7 @@ export * from "./module";
 becomes
 ```js
 module.watch(require("./module"), {
-  "*": (value, name) => {
+  ["*"](value, name) {
     exports[name] = value;
   }
 });
@@ -314,7 +314,7 @@ becomes
 ```js
 exports.ns = Object.create(null);
 module.watch(require("./module"), {
-  "*": (value, name) => {
+  ["*"](value, name) {
     exports.ns[name] = value;
   }
 });
@@ -327,9 +327,9 @@ export a, { b, c as d } from "./module";
 becomes
 ```js
 module.watch(require("./module"), {
-  default: value => { exports.a = value },
-  b: value => { exports.b = value },
-  c: value => { exports.d = value }
+  default(value) { exports.a = value; },
+  b(value) { exports.b = value; },
+  c(value) { exports.d = value; }
 });
 ```
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -28,30 +28,28 @@ function compile(code, options) {
   }
 
   const parse = getOption(options, "parse");
+  const sourceType = getOption(options, "sourceType");
   const ast = parse(code);
+
   const result = {
     ast,
     code,
-    identical: false
+    identical: true,
+    sourceType: "script"
   };
-
-  const sourceType = getOption(options, "sourceType");
 
   if (sourceType === "script" ||
       (sourceType === "unambiguous" && ! importExportRegExp.test(code))) {
-    // Let the caller know the result is no different from the input.
-    result.identical = true;
     return result;
   }
 
   const rootPath = new FastPath(ast);
   options.moduleAlias = makeUniqueId(getOption(options, "moduleAlias"), code);
+
   importExportVisitor.visit(rootPath, code, options);
-
   const magicString = importExportVisitor.magicString;
-  result.identical = ! importExportVisitor.madeChanges;
 
-  if (! result.identical || sourceType === "module") {
+  if (importExportVisitor.madeChanges) {
     assignmentVisitor.visit(rootPath, {
       exportedLocalNames: importExportVisitor.exportedLocalNames,
       magicString: magicString,
@@ -60,19 +58,14 @@ function compile(code, options) {
     });
 
     importExportVisitor.finalizeHoisting();
+    result.identical = false;
+  }
 
-    if (! getOption(options, "repl")) {
-      result.code =
-        "module.run(function(){" +
-        magicString.toString() +
-        "\n})";
-
-      return result;
-    }
+  if (! result.identical || sourceType !== "unambiguous") {
+    result.sourceType = "module";
   }
 
   result.code = magicString.toString();
-
   return result;
 }
 
@@ -81,9 +74,9 @@ exports.compile = compile;
 function makeUniqueId(id, code) {
   let match;
   let n = -1;
-  const scan = new RegExp("\\b" + id + "(\\d*)\\b", "g");
+  const scanRegExp = new RegExp("\\b" + id + "(\\d*)\\b", "g");
 
-  while ((match = scan.exec(code))) {
+  while ((match = scanRegExp.exec(code))) {
     n = Math.max(n, +(match[1] || 0));
   }
 

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -18,12 +18,6 @@ class ImportExportVisitor extends Visitor {
       const bodyInfo = this.bodyInfos[i];
       let codeToInsert = "";
 
-      if (bodyInfo.needToAddUseStrictDirective &&
-          (this.madeChanges || isModule)) {
-        this.madeChanges = true;
-        codeToInsert += '"use strict";';
-      }
-
       if (bodyInfo.parent.type === "Program" &&
           this.moduleAlias !== "module") {
         codeToInsert +=
@@ -58,13 +52,6 @@ class ImportExportVisitor extends Visitor {
 
           const body = bodyInfo.body;
           body.splice.apply(body, spliceArgs);
-
-          const parsedDirectives = ast.directives;
-          const parentDirectives = bodyInfo.parent.directives;
-
-          if (parsedDirectives && parentDirectives) {
-            parentDirectives.push.apply(parentDirectives, parsedDirectives);
-          }
         }
       }
 
@@ -91,7 +78,6 @@ class ImportExportVisitor extends Visitor {
     }
 
     this.bodyInfos = [];
-    this.enforceStrictMode = getOption(options, "enforceStrictMode");
     this.exportedLocalNames = Object.create(null);
     this.generateArrowFunctions = !! getOption(options, "generateArrowFunctions");
     this.generateLetDeclarations = !! getOption(options, "generateLetDeclarations");
@@ -432,15 +418,10 @@ function getBlockBodyInfo(visitor, path) {
   let body = parent.body;
   let bodyName = "body";
   let insertCharIndex = node.start;
-  let needToAddUseStrictDirective = false;
 
   switch (parent.type) {
   case "Program":
     insertCharIndex = parent.start;
-
-    // If parent is a Program, we may need to add a "use strict"
-    // directive to enable const/let in Node 4.
-    needToAddUseStrictDirective = visitor.enforceStrictMode;
     break;
 
   case "BlockStatement":
@@ -493,11 +474,6 @@ function getBlockBodyInfo(visitor, path) {
           typeof expr.value === "string")) {
         insertCharIndex = stmt.end;
         insertNodeIndex = i + 1;
-        if (expr.value === "use strict") {
-          // If there's already a "use strict" directive, then we don't
-          // need to add another one.
-          needToAddUseStrictDirective = false;
-        }
         continue;
       }
     }
@@ -510,13 +486,7 @@ function getBlockBodyInfo(visitor, path) {
   const directiveCount = directives ? directives.length : 0;
 
   for (let i = 0; i < directiveCount; ++i) {
-    const d = directives[i];
-    insertCharIndex = Math.max(d.end, insertCharIndex);
-    if (d.value.value === "use strict") {
-      // If there's already a "use strict" directive, then we don't
-      // need to add another one.
-      needToAddUseStrictDirective = false;
-    }
+    insertCharIndex = Math.max(directives[i].end, insertCharIndex);
   }
 
   let bibn = parent._bodyInfoByName;
@@ -540,10 +510,6 @@ function getBlockBodyInfo(visitor, path) {
 
   } else {
     assert.strictEqual(bodyInfo.body, body);
-  }
-
-  if (needToAddUseStrictDirective) {
-    bodyInfo.needToAddUseStrictDirective = needToAddUseStrictDirective;
   }
 
   return bodyInfo;

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -81,6 +81,7 @@ class ImportExportVisitor extends Visitor {
     this.exportedLocalNames = Object.create(null);
     this.generateArrowFunctions = !! getOption(options, "generateArrowFunctions");
     this.generateLetDeclarations = !! getOption(options, "generateLetDeclarations");
+    this.generateShorthandMethodNames = !! getOption(options, "generateShorthandMethodNames");
     this.madeChanges = false;
     this.modifyAST = !! getOption(options, "modifyAST");
     this.moduleAlias = getOption(options, "moduleAlias");
@@ -182,7 +183,9 @@ class ImportExportVisitor extends Visitor {
       decl.source.start
     ) + pad(
       this,
-      ',{"*":function(v,k){exports[k]=v}},' +
+      ",{" +
+      (this.generateShorthandMethodNames ? '["*"]' : '"*":function') +
+      "(v,k){exports[k]=v}}," +
         makeUniqueKey(this) + ");",
       decl.source.end,
       decl.end
@@ -720,11 +723,12 @@ function processRemoval(removal) {
   }
 }
 
-function safeKey(key) {
+function safeKey(key, isComputed) {
   if (/^[_$a-zA-Z]\w*$/.test(key)) {
     return key;
   }
-  return JSON.stringify(key);
+  key = JSON.stringify(key);
+  return isComputed ? ("[" + key + "]") : key;
 }
 
 function safeParam(param, locals) {
@@ -760,9 +764,13 @@ function toModuleImport(visitor, source, specifierMap, namespaces) {
 
     // Generate plain functions, instead of arrow functions, to avoid a perf
     // hit in Node 4.
-    code +=
-      safeKey(imported) +
-      ":function(" + valueParam;
+    code += safeKey(imported, visitor.generateShorthandMethodNames);
+
+    if (! visitor.generateShorthandMethodNames) {
+      code += ":function";
+    }
+
+    code += "(" + valueParam;
 
     if (imported === "*") {
       // When the imported name is "*", the setter function may be called
@@ -825,12 +833,14 @@ function toModuleExport(visitor, specifierMap, constant) {
 
     assert.strictEqual(locals.length, 1);
 
-    code += exported + ":";
+    code += exported;
 
     if (visitor.generateArrowFunctions) {
-      code += "()=>" + locals[0];
+      code += ":()=>" + locals[0];
     } else {
-      code += "function(){return " + locals[0] + "}";
+      code +=
+        (visitor.generateShorthandMethodNames ? "" : ":function") +
+        "(){return " + locals[0] + "}";
     }
 
     if (! isLast) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,8 +3,6 @@
 const hasOwn = Object.prototype.hasOwnProperty;
 
 const defaultOptions = {
-  // If true, a "use strict" directive is added to code evaluated as an ES module.
-  enforceStrictMode: true,
   generateArrowFunctions: true,
   generateLetDeclarations: false,
   modifyAST: false,

--- a/lib/options.js
+++ b/lib/options.js
@@ -5,6 +5,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 const defaultOptions = {
   generateArrowFunctions: true,
   generateLetDeclarations: false,
+  generateShorthandMethodNames: true,
   modifyAST: false,
   moduleAlias: "module",
   // If true, generate code appropriate for an interactive REPL session.

--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -171,4 +171,3 @@ function setESModuleAndOwner(mod) {
 }
 
 module.exports = Runtime;
-

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const getOption = require("./options.js").get;
+
 const AV = require("./assignment-visitor.js");
 const FastPath = require("./fast-path.js");
 const IEV = require("./import-export-visitor.js");
@@ -11,15 +13,17 @@ function transform(ast, options) {
   options = Object.assign(Object.create(null), options);
   options.modifyAST = true;
 
+  const code = null;
+
+  const result = {
+    ast,
+    code,
+    identical: true,
+    sourceType: "script"
+  };
+
   const rootPath = new FastPath(ast);
-
-  importExportVisitor.visit(
-    rootPath,
-    null, // No code to modify.
-    options
-  );
-
-  const result = { ast, identical: false };
+  importExportVisitor.visit(rootPath, code, options);
 
   if (importExportVisitor.madeChanges) {
     assignmentVisitor.visit(rootPath, {
@@ -28,10 +32,11 @@ function transform(ast, options) {
     });
 
     importExportVisitor.finalizeHoisting();
+    result.identical = false;
+  }
 
-  } else {
-    // Let the caller know the result is no different from the input.
-    result.identical = true;
+  if (! result.identical || getOption(options, "sourceType") !== "unambiguous") {
+    result.sourceType = "module";
   }
 
   return result;

--- a/node/caching-compiler.js
+++ b/node/caching-compiler.js
@@ -26,16 +26,16 @@ function compileWithFilename(content, options) {
 
 function compileAndCache(content, options) {
   const result = compiler.compile(content, toCompileOptions(options));
-  return options.pkgInfo.cache[options.cacheFilename] = result.code;
+  return options.pkgInfo.cache[options.cacheFilename] = result;
 }
 
 function compileAndWrite(content, options) {
-  const result = compiler.compile(content, toCompileOptions(options));
-  const code = result.code;
+  const compileOptions = toCompileOptions(options);
+  const result = compiler.compile(content, compileOptions);
 
-  if (! result.identical) {
-    // Only cache if the compiler made changes.
+  if (result.sourceType === "module") {
     const cacheFilePath = path.join(options.cachePath, options.cacheFilename);
+    const code = result.code;
     const isGzipped = path.extname(cacheFilePath) === ".gz";
     const content = () => isGzipped ? fs.gzip(code) : code;
     const encoding = isGzipped ? null : "utf8";
@@ -44,7 +44,7 @@ function compileAndWrite(content, options) {
     fs.writeFileDefer(cacheFilePath, content, { encoding, scopePath });
   }
 
-  return code;
+  return result;
 }
 
 function toCompileOptions(options) {

--- a/node/index.js
+++ b/node/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const runtime = require("./runtime.js");
 const setDefaults = require("../lib/options.js").setDefaults;
+const Runtime = require("./runtime.js");
 
 let isDefaultsSet = false;
 const parentModule = module.parent || __non_webpack_module__.parent;
@@ -16,4 +16,4 @@ module.exports = (options) => {
 require("./compile-hook.js");
 require("./repl-hook.js");
 
-runtime.enable(parentModule);
+Runtime.enable(parentModule);

--- a/node/utils.js
+++ b/node/utils.js
@@ -159,6 +159,7 @@ function readPkgInfo(dirPath) {
     // contents of the file, but for now we merely register that it exists.
     pkgInfo.cache[cacheFiles[i]] = true;
   }
+
   return pkgInfo;
 }
 

--- a/packages/custom-cache-example/README.md
+++ b/packages/custom-cache-example/README.md
@@ -23,9 +23,9 @@ then
 
 ```sh
 % ls .reify-custom-cache
-a2f2d6b8b16ddbc496993cb55f3621f5fe4e5f1a.json
+a2f2d6b8b16ddbc496993cb55f3621f5fe4e5f1a.js
 
-% cat .reify-custom-cache/a2f2d6b8b16ddbc496993cb55f3621f5fe4e5f1a.json
-module.export({name:function(){return name}});var basename;module.import("path",{"basename":function(v){basename=v}},0);
+% cat .reify-custom-cache/a2f2d6b8b16ddbc496993cb55f3621f5fe4e5f1a.js
+module.export({name:()=>name});var basename;module.import("path",{basename(v){basename=v}},0);
 var name = basename(module.id);
 ```

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -55,18 +55,15 @@ describe("compiler", () => {
   it("should respect options.generateArrowFunctions", () => {
     import { compile } from "../lib/compiler.js";
 
-    const source = [
-      'import def from "mod"',
-      "export { def as x }"
-    ].join("\n");
+    const code = "export let a = 1;";
 
-    const withoutArrow = compile(source, {
+    const withoutArrow = compile(code, {
       generateArrowFunctions: false
     }).code;
 
     assert.ok(! withoutArrow.includes("=>"));
 
-    const withArrow = compile(source, {
+    const withArrow = compile(code, {
       generateArrowFunctions: true
     }).code;
 
@@ -74,9 +71,7 @@ describe("compiler", () => {
 
     // No options.generateArrowFunctions is the same as
     // { generateArrowFunctions: true }.
-    const defaultArrow = compile(
-      source
-    ).code;
+    const defaultArrow = compile(code).code;
 
     assert.ok(defaultArrow.includes("=>"));
   });
@@ -84,27 +79,49 @@ describe("compiler", () => {
   it("should respect options.generateLetDeclarations", () => {
     import { compile } from "../lib/compiler.js";
 
-    const source = 'import foo from "./foo"';
+    const code = 'import def from "mod"';
 
-    const withLet = compile(source, {
+    const withLet = compile(code, {
       generateLetDeclarations: true
     }).code;
 
-    assert.ok(withLet.startsWith("let foo;"));
+    assert.ok(withLet.startsWith("let def;"));
 
-    const withoutLet = compile(source, {
+    const withoutLet = compile(code, {
       generateLetDeclarations: false
     }).code;
 
-    assert.ok(withoutLet.startsWith("var foo;"));
+    assert.ok(withoutLet.startsWith("var def;"));
 
     // No options.generateLetDeclarations is the same as
     // { generateLetDeclarations: false }.
-    const defaultLet = compile(
-      source
-    ).code;
+    const defaultLet = compile(code).code;
 
-    assert.ok(defaultLet.startsWith("var foo;"));
+    assert.ok(defaultLet.startsWith("var def;"));
+  });
+
+  it("should respect options.generateShorthandMethodNames", () => {
+    import { compile } from "../lib/compiler.js";
+
+    const code = 'import def from "mod"';
+
+    const withoutShorthand = compile(code, {
+      generateShorthandMethodNames: false
+    }).code;
+
+    assert.ok(withoutShorthand.includes(":function"));
+
+    const withShorthand = compile(code, {
+      generateShorthandMethodNames: true
+    }).code;
+
+    assert.ok(! withShorthand.includes(":function"));
+
+    // No options.generateShorthandMethodNames is the same as
+    // { generateShorthandMethodNames: true }.
+    const defaultShorthand = compile(code).code;
+
+    assert.ok(! defaultShorthand.includes(":function"));
   });
 
   it("should respect options.modifyAST", () => {
@@ -176,8 +193,8 @@ describe("compiler", () => {
     const sourceTypes = [void 0, "module", "unambiguous"];
 
     sourceTypes.forEach((sourceType) => {
-      const actual = compile(code, { sourceType }).code;
-      assert.ok(actual.includes("module.watch"));
+      const result = compile(code, { sourceType });
+      assert.ok(result.code.includes("module.watch"));
     });
 
     const scriptType = compile(code, {
@@ -204,7 +221,6 @@ describe("compiler", () => {
 
     const anonCode = "export default class {}";
     const anonAST = parse(anonCode);
-
     const anonFirstIndex =
       isUseStrictExprStmt(anonAST.body[0]) ? 1 : 0;
 
@@ -216,7 +232,6 @@ describe("compiler", () => {
 
     const namedCode = "export default class C {}";
     const namedAST = parse(namedCode);
-
     const namedFirstIndex =
       isUseStrictExprStmt(namedAST.body[0]) ? 1 : 0;
 

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -52,32 +52,6 @@ describe("compiler", () => {
     assert.strictEqual(check(), true);
   });
 
-  it("should respect options.enforceStrictMode", () => {
-    import { compile } from "../lib/compiler.js";
-
-    const source = 'import "a"';
-
-    const withoutStrict = compile(source, {
-      enforceStrictMode: false
-    }).code;
-
-    assert.ok(! withoutStrict.startsWith('module.run(function(){"use strict"'));
-
-    const withStrict = compile(source, {
-      enforceStrictMode: true
-    }).code;
-
-    assert.ok(withStrict.startsWith('module.run(function(){"use strict"'));
-
-    // No options.enforceStrictMode is the same as
-    // { enforceStrictMode: true }.
-    const defaultStrict = compile(
-      source
-    ).code;
-
-    assert.ok(defaultStrict.startsWith('module.run(function(){"use strict"'));
-  });
-
   it("should respect options.generateArrowFunctions", () => {
     import { compile } from "../lib/compiler.js";
 
@@ -116,13 +90,13 @@ describe("compiler", () => {
       generateLetDeclarations: true
     }).code;
 
-    assert.ok(withLet.startsWith('module.run(function(){"use strict";let foo;'));
+    assert.ok(withLet.startsWith("let foo;"));
 
     const withoutLet = compile(source, {
       generateLetDeclarations: false
     }).code;
 
-    assert.ok(withoutLet.startsWith('module.run(function(){"use strict";var foo;'));
+    assert.ok(withoutLet.startsWith("var foo;"));
 
     // No options.generateLetDeclarations is the same as
     // { generateLetDeclarations: false }.
@@ -130,7 +104,7 @@ describe("compiler", () => {
       source
     ).code;
 
-    assert.ok(defaultLet.startsWith('module.run(function(){"use strict";var foo;'));
+    assert.ok(defaultLet.startsWith("var foo;"));
   });
 
   it("should respect options.modifyAST", () => {
@@ -191,46 +165,26 @@ describe("compiler", () => {
     });
 
     assert.strictEqual(result.ast, ast);
-    assert.ok(result.code.startsWith('module.run(function(){"use strict";let foo'));
+    assert.ok(result.code.startsWith("let foo"));
     assert.ok(result.code.includes('"./+@#"'));
   });
 
   it("should respect options.sourceType", () => {
     import { compile } from "../lib/compiler.js";
 
-    const source = "1+2;";
+    const code = 'import "a"';
+    const sourceTypes = [void 0, "module", "unambiguous"];
 
-    const moduleType = compile(source, {
-      sourceType: "module"
-    }).code;
+    sourceTypes.forEach((sourceType) => {
+      const actual = compile(code, { sourceType }).code;
+      assert.ok(actual.includes("module.watch"));
+    });
 
-    assert.ok(moduleType.startsWith('module.run(function(){"use strict"'));
-
-    const unambiguousAsCJS = compile(source, {
-      sourceType: "unambiguous"
-    }).code;
-
-    assert.ok(! unambiguousAsCJS.startsWith('module.run(function(){"use strict"'));
-
-    const unambiguousAsESM = compile('import "a"\n' + source, {
-      sourceType: "unambiguous"
-    }).code;
-
-    assert.ok(unambiguousAsESM.startsWith('module.run(function(){"use strict"'));
-
-    const scriptType = compile('import "a"\n' + source, {
+    const scriptType = compile(code, {
       sourceType: "script"
     }).code;
 
-    assert.ok(scriptType.startsWith('import "a"'));
-
-    // No options.sourceType is the same as
-    // { sourceType: "unambiguous" }.
-    const defaultType = compile(
-      source
-    ).code;
-
-    assert.ok(! defaultType.startsWith('module.run(function(){"use strict"'));
+    assert.strictEqual(scriptType, code);
   });
 
   it("should transform default export declaration to expression", () => {
@@ -282,14 +236,14 @@ describe("compiler", () => {
     ].join("\n");
 
     const result = compile(code);
-    assert.ok(result.code.startsWith('module.run(function(){"use strict";var a;'));
+    assert.ok(result.code.startsWith("var a;"));
   });
 
   it("should not get confused by trailing comments", () => {
     import { compile } from "../lib/compiler.js";
 
     const result = compile('import "a" // trailing comment');
-    assert.ok(result.code.endsWith("// trailing comment\n})"));
+    assert.ok(result.code.endsWith("// trailing comment"));
   });
 
   it("should preserve crlf newlines", () => {

--- a/test/output/anon-class/expected.js
+++ b/test/output/anon-class/expected.js
@@ -1,7 +1,5 @@
-module.run(function(){"use strict";module.exportDefault(class {
+module.exportDefault(class {
   constructor(value) {
     this.value = value;
   }
 });
-
-})

--- a/test/output/declarations-basic/expected.js
+++ b/test/output/declarations-basic/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({c:()=>c,d:()=>d});module.export({a:()=>a,b:()=>b},true);const a = 1;
+module.export({c:()=>c,d:()=>d});module.export({a:()=>a,b:()=>b},true);const a = 1;
 const b = function () {
   return d;
 };
@@ -8,5 +8,3 @@ function d() {
 };
 
 module.runSetters(c = "c");
-
-})

--- a/test/output/default-expression/expected.js
+++ b/test/output/default-expression/expected.js
@@ -1,7 +1,5 @@
-module.run(function(){"use strict";let count = 0;
+let count = 0;
 
 // This default expression will evaluate to 0 if the parentheses are
 // mistakenly stripped away.
 module.exportDefault((count++, count));
-
-})

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v}},0);
+module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual(v){strictEqual=v}},0);
 
 const obj = {};
 

--- a/test/output/default-function/expected.js
+++ b/test/output/default-function/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v}},0);
+module.export({default:()=>f,check:()=>check});var strictEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v}},0);
 
 const obj = {};
 
@@ -11,5 +11,3 @@ function check(g) {
   strictEqual(f(), obj);
   strictEqual(g(), obj);
 }
-
-})

--- a/test/output/eval/expected.js
+++ b/test/output/eval/expected.js
@@ -1,7 +1,5 @@
-module.run(function(){"use strict";module.export({value:()=>localValue,run:()=>run});let localValue = "original";
+module.export({value:()=>localValue,run:()=>run});let localValue = "original";
 
 function run(code) {
   return module.runSetters(eval(code));
 };
-
-})

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,5 +1,1 @@
-module.run(function(){"use strict";module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0,[n]);
-
-
-
-})
+module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0,[n]);

--- a/test/output/export-all-multiple/expected.js
+++ b/test/output/export-all-multiple/expected.js
@@ -1,1 +1,1 @@
-module.export({Abc:()=>n});module.watch(require("./def"),{"*":function(v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{"*":function(v,_n){n[_n]=v}},0,[n]);
+module.export({Abc:()=>n});module.watch(require("./def"),{["*"](v,k){exports[k]=v}},1);var n=Object.create(null);module.watch(require("./abc"),{["*"](v,_n){n[_n]=v}},0,[n]);

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,2 +1,2 @@
-module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
+module.watch(require("./abc"),{["*"](v,k){exports[k]=v}},0);
 module.exportDefault("default");

--- a/test/output/export-all/expected.js
+++ b/test/output/export-all/expected.js
@@ -1,4 +1,2 @@
-module.run(function(){"use strict";module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
+module.watch(require("./abc"),{"*":function(v,k){exports[k]=v}},0);
 module.exportDefault("default");
-
-})

--- a/test/output/export-multi-namespace/expected.js
+++ b/test/output/export-multi-namespace/expected.js
@@ -1,1 +1,1 @@
-var module1=module;exports.a=Object.create(null);exports.b=Object.create(null);module1.watch(require("module"),{"*":function(v,n){exports.a[n]=exports.b[n]=v}},0,[exports.a,exports.b]);
+var module1=module;exports.a=Object.create(null);exports.b=Object.create(null);module1.watch(require("module"),{["*"](v,n){exports.a[n]=exports.b[n]=v}},0,[exports.a,exports.b]);

--- a/test/output/export-multi-namespace/expected.js
+++ b/test/output/export-multi-namespace/expected.js
@@ -1,3 +1,1 @@
-module.run(function(){"use strict";var module1=module;exports.a=Object.create(null);exports.b=Object.create(null);module1.watch(require("module"),{"*":function(v,n){exports.a[n]=exports.b[n]=v}},0,[exports.a,exports.b]);
-
-})
+var module1=module;exports.a=Object.create(null);exports.b=Object.create(null);module1.watch(require("module"),{"*":function(v,n){exports.a[n]=exports.b[n]=v}},0,[exports.a,exports.b]);

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
+module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
 
 
 module.runSetters(cee += "ee");
@@ -7,5 +7,3 @@ module.runSetters(cee += "ee");
 function c() {
   return "c";
 }
-
-})

--- a/test/output/export-some/expected.js
+++ b/test/output/export-some/expected.js
@@ -1,4 +1,4 @@
-module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a:function(v){exports.a=v},b:function(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c:function(v){cee=v}},1);
+module.export({si:()=>cee,c:()=>c});module.watch(require("./abc"),{a(v){exports.a=v},b(v){exports.v=v}},0);var cee;module.watch(require("./abc.js"),{c(v){cee=v}},1);
 
 
 module.runSetters(cee += "ee");

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
+module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
 
 
 
@@ -15,5 +15,3 @@ function check()
   const line = +error.stack.split("\n")[1].split(":")[1];
   strictEqual(line, 14);
 }
-
-})

--- a/test/output/lines/expected.js
+++ b/test/output/lines/expected.js
@@ -1,4 +1,4 @@
-module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual:function(v){strictEqual=v},deepEqual:function(v){deepEqual=v}},0);
+module.export({default:()=>check});var strictEqual,deepEqual;module.watch(require("assert"),{strictEqual(v){strictEqual=v},deepEqual(v){deepEqual=v}},0);
 
 
 

--- a/test/output/live/expected.js
+++ b/test/output/live/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
+module.export({value:()=>value,reset:()=>reset,add:()=>add});var value = reset();
 
 function reset() {
   return module.runSetters(value = 0);
@@ -7,5 +7,3 @@ function reset() {
 function add(x) {
   module.runSetters(value += x);
 };
-
-})

--- a/test/output/mixed-keys/expected.js
+++ b/test/output/mixed-keys/expected.js
@@ -1,1 +1,1 @@
-var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1,[$2]);
+var _1,$1;module.watch(require("./a"),{_1(v){_1=v},$1(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default(v){_2=v},["*"](v,n){$2[n]=v}},1,[$2]);

--- a/test/output/mixed-keys/expected.js
+++ b/test/output/mixed-keys/expected.js
@@ -1,4 +1,1 @@
-module.run(function(){"use strict";var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1,[$2]);
-
-
-})
+var _1,$1;module.watch(require("./a"),{_1:function(v){_1=v},$1:function(v){$1=v}},0);var _2;var $2=Object.create(null);module.watch(require("./a"),{default:function(v){_2=v},"*":function(v,n){$2[n]=v}},1,[$2]);

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,6 +1,4 @@
-module.run(function(){"use strict";var module1=module;module1.export({id:()=>id,name:()=>name},true);const path = require("path");
+var module1=module;module1.export({id:()=>id,name:()=>name},true);const path = require("path");
 
 const id = module.id,
   name = path.basename(__filename);
-
-})

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a:function(v){ay=v}},0);var bee;module.watch(require("./abc"),{b:function(v){bee=v}},1);var see;module.watch(require("./abc"),{c:function(v){see=v}},2);
+module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a(v){ay=v}},0);var bee;module.watch(require("./abc"),{b(v){bee=v}},1);var see;module.watch(require("./abc"),{c(v){see=v}},2);
 
 
 

--- a/test/output/nested/expected.js
+++ b/test/output/nested/expected.js
@@ -1,4 +1,4 @@
-module.run(function(){"use strict";module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a:function(v){ay=v}},0);var bee;module.watch(require("./abc"),{b:function(v){bee=v}},1);var see;module.watch(require("./abc"),{c:function(v){see=v}},2);
+module.export({outer:()=>outer});function outer() {var ay;module.watch(require("./abc"),{a:function(v){ay=v}},0);var bee;module.watch(require("./abc"),{b:function(v){bee=v}},1);var see;module.watch(require("./abc"),{c:function(v){see=v}},2);
 
 
 
@@ -8,5 +8,3 @@ module.run(function(){"use strict";module.export({outer:()=>outer});function out
     see
   ];
 }
-
-})

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,5 +1,3 @@
-module.run(function(){"use strict";var module1=module;function f() {var a,c;module1.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
+var module1=module;function f() {var a,c;module1.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
 
 }
-
-})

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,3 +1,3 @@
-var module1=module;function f() {var a,c;module1.watch(require("./module"),{a:function(v){a=v},b:function(v){c=v}},0);
+var module1=module;function f() {var a,c;module1.watch(require("./module"),{a(v){a=v},b(v){c=v}},0);
 
 }

--- a/test/repl-tests.js
+++ b/test/repl-tests.js
@@ -1,4 +1,4 @@
-const assert = require("assert");
+import assert from "assert";
 
 // Masquerade as the REPL module.
 module.filename = null;
@@ -12,11 +12,11 @@ describe("Node REPL", () => {
   import "../node/repl-hook.js";
   import { createContext } from "vm";
   import repl from "repl";
-  import runtime from "../node/runtime.js";
+  import Runtime from "../node/runtime.js";
 
   it("should work with global context", (done) => {
     const r = repl.start({ useGlobal: true });
-    runtime.enable(r.context.module);
+    Runtime.enable(r.context.module);
 
     assert.strictEqual(typeof assertStrictEqual, "undefined");
 

--- a/test/setter-tests.js
+++ b/test/setter-tests.js
@@ -50,7 +50,7 @@ describe("parent setters", () => {
 
     reset();
     module.importSync("./misc/live.js", {
-      value: (v) => {
+      value(v) {
         ++firstCallCount;
         value = "first:" + v;
       }
@@ -64,7 +64,7 @@ describe("parent setters", () => {
     assert.strictEqual(secondCallCount, 0);
 
     module.importSync("./misc/live.js", {
-      value: (v) => {
+      value(v) {
         ++secondCallCount;
         value = "second:" + v;
       }
@@ -83,34 +83,35 @@ describe("parent setters", () => {
     // Manually register setters for value and set, which are marked as
     // constant in the fake-const.js module, even though they are actually
     // mutable (see below).
-    let value, set;
+    let set;
+    let value;
     let valueSetterCallCount = 0;
     module.watch(require("./setter/fake-const.js"), {
-      value: v => {
+      set(v) {
+        set = v;
+      },
+      value(v) {
         value = v;
         valueSetterCallCount += 1;
-      },
-      set: v => set = v
+      }
     });
 
-    // Because the getter for value in fake-const.js throws, the initial
-    // value here is undefined, and our live binding to that value is
-    // maintained for now.
+    // Because the getter for value in fake-const.js throws, the initial value
+    // here is undefined, and our live binding to that value is maintained,
+    // for now.
     assert.strictEqual(value, void 0);
     assert.strictEqual(valueSetterCallCount, 1);
 
-    // Since the exported value is marked as constant, the setter that
-    // updates our copy of value should be discarded as soon as it has
-    // been called with the final value, but this set(2) still works
-    // because the getter threw the last time it was called. After this,
-    // however, the setter function will be discarded.
+    // Because the exported value is marked as constant, the setter that updates
+    // our copy of value should be discarded as soon as it has been called.
+    // However, this set(2) still works because the getter threw the last time
+    // it was called. After this, though, the setter will be discarded.
     set(2);
     assert.strictEqual(value, 2);
     assert.strictEqual(valueSetterCallCount, 2);
 
-    // Because the exported value is marked as constant, this set(3) is
-    // not reflected in this scope, because the setter that we registered
-    // above has been thrown away.
+    // The setter that we registered above has been discarded so this set(3)
+    // is not reflected in this scope.
     set(3);
     assert.strictEqual(value, 2);
     assert.strictEqual(valueSetterCallCount, 2);

--- a/test/setter/fake-const.js
+++ b/test/setter/fake-const.js
@@ -1,9 +1,11 @@
-module.run(function () {
-  "use strict";
+"use strict";
 
-  // Throw once for the mod.runSetters call in module.run, and again for the
-  // first time we call module.runSetters in set below.
-  let throwTimes = 2;
+require("../../node/runtime.js").enable(module);
+
+module.run(function () {
+  // Throw for the runSetters call in the compile-hook, module.run,
+  // and for the first time we call runSetters in set below.
+  let throwTimes = 3;
   let value = 1;
 
   function set(to) {
@@ -11,7 +13,7 @@ module.run(function () {
   }
 
   module.export({
-    value: () => {
+    value() {
       if (throwTimes-- > 0) {
         throw new Error("simulated");
       }


### PR DESCRIPTION
This PR moves the `module.run` wrapper to the compile-hook. This allows us to customize wrapper per option/source-type and simplifies parsing a bit.

Things to note:

* The compiler `result` now includes a `sourceType` that specifies what type it compiled as

* The `enforceStrictMode` option is removed since `"use strict";` is handled by the compile-hook wrap and not generated by the compiler

* ESM output is cached even if output is identical to simplify loading logic
  *(since side-effect only modules are rare so shouldn't add overhead)*

* Runtime is only enabled for ESM
   *(I side step extending CJS by using `Runtime.prototype.runSetters`)*
