### PR TITLE
Guide AST traversal based on a RegExp scan of possible indexes.

### DIFF
--- a/lib/assignment-visitor.js
+++ b/lib/assignment-visitor.js
@@ -17,6 +17,22 @@ class AssignmentVisitor extends Visitor {
     if (this.magicString === void 0) {
       this.magicString = null;
     }
+
+    if (this.magicString) {
+      const identifiers = Object.keys(this.exportedLocalNames);
+
+      // In addition to any exported local identifiers, this visitor needs
+      // to visit `eval(...)` expressions, so it's important to search for
+      // any possible indexes of the `eval` identifier, too.
+      identifiers.push("eval");
+
+      // When this.possibleIndexes is defined, the AST traversal can
+      // abandon any subtrees that do not contain any possible indexes.
+      this.possibleIndexes = utils.findPossibleIndexes(
+        this.magicString.original,
+        identifiers
+      );
+    }
   }
 
   visitAssignmentExpression(path) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -13,12 +13,7 @@ const importExportVisitor = new IEV;
 const codeOfPound = "#".charCodeAt(0);
 const shebangRegExp = /^#!.*/;
 
-// Matches any import or export identifier as long as it's not preceded by
-// a `.` character (to avoid matching module.export, for example). Because
-// Reify replaces all import and export declarations with module.import
-// and module.export calls, this logic should prevent the compiler from
-// ever having to recompile code it has already compiled.
-const importExportRegExp = /(?:^|[^.])\b(?:im|ex)port\b/;
+const utils = require("./utils.js");
 
 exports.compile = function (code, options) {
   options = Object.assign(Object.create(null), options);
@@ -27,28 +22,33 @@ exports.compile = function (code, options) {
     code = code.replace(shebangRegExp, "");
   }
 
-  const parse = getOption(options, "parse");
-  const ast = parse(code);
   const result = {
     code,
     ast: null,
     identical: false
   };
 
+  // Quickly scan the code to find all possible indexes of import or
+  // export keywords, tolerating some false positives.
+  options.possibleIndexes =
+    utils.findPossibleIndexes(code, ["import", "export"]);
+
+  const parse = getOption(options, "parse");
+  const sourceType = getOption(options, "sourceType");
+  const hasImportsOrExports = options.possibleIndexes.length > 0;
+
   if (getOption(options, "ast")) {
-    result.ast = ast;
+    result.ast = parse(code);
   }
 
-  const sourceType = getOption(options, "sourceType");
-
   if (sourceType === "script" ||
-      (sourceType === "unambiguous" && ! importExportRegExp.test(code))) {
+      (sourceType === "unambiguous" && ! hasImportsOrExports)) {
     // Let the caller know the result is no different from the input.
     result.identical = true;
     return result;
   }
 
-  const rootPath = new FastPath(ast);
+  const rootPath = new FastPath(result.ast || parse(code));
   options.moduleAlias = makeUniqueId(getOption(options, "moduleAlias"), code);
   importExportVisitor.visit(rootPath, code, options);
 

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -126,6 +126,7 @@ class ImportExportVisitor extends Visitor {
     this.removals = [];
     this.sourceType = getOption(options, "sourceType");
     this.moduleAlias = getOption(options, "moduleAlias");
+    this.possibleIndexes = getOption(options, "possibleIndexes");
   }
 
   visitProgram(path) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,3 +90,36 @@ function toString(value) {
 }
 
 exports.toString = toString;
+
+// Returns a sorted array of possible indexes within the code string where
+// any identifier in the identifiers array might appear. This information
+// can be used to optimize AST traversal by allowing subtrees to be
+// ignored if they don't contain any possible indexes.
+function findPossibleIndexes(code, identifiers) {
+  const possibleIndexes = [];
+
+  if (identifiers.length === 0) {
+    return possibleIndexes;
+  }
+
+  const pattern = new RegExp(
+    "\\b(?:" + identifiers.join("|") + ")\\b",
+    "g"
+  );
+
+  let match;
+  pattern.lastIndex = 0;
+  while ((match = pattern.exec(code))) {
+    // Make sure the match is not preceded by a `.` character, since that
+    // probably means the identifier is a property access rather than a
+    // variable reference.
+    if (match.index < 1 ||
+        code.charAt(match.index - 1) !== ".") {
+      possibleIndexes.push(match.index);
+    }
+  }
+
+  return possibleIndexes;
+}
+
+exports.findPossibleIndexes = findPossibleIndexes;

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -151,17 +151,25 @@ class Visitor {
 
     for (let i = 0; i < keyCount; ++i) {
       const key = keys[i];
+
+      // Ignore .loc.{start,end} objects.
+      if (key === "loc") {
+        continue;
+      }
+
+      // Ignore "private" properties added by Babel.
+      if (key.charCodeAt(0) === codeOfUnderscore) {
+        continue;
+      }
+
       const value = node[key];
 
-      if (
-          // Ignore .loc.{start,end} objects.
-          key !== "loc" &&
-          // Ignore "private" properties added by Babel.
-          key.charCodeAt(0) !== codeOfUnderscore &&
-          // Ignore properties whose values aren't objects.
-          utils.isObject(value)) {
-        path.call(this.visitWithoutReset, key);
+      // Ignore properties whose values aren't objects.
+      if (! utils.isObject(value)) {
+        continue;
       }
+
+      path.call(this.visitWithoutReset, key);
     }
   }
 };

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -42,10 +42,76 @@ class Visitor {
       if (typeof method === "function") {
         // The method must call this.visitChildren(path) to continue traversing.
         method.call(this, path);
-      } else {
+      } else if (this._nodeContainsPossibleIndex(value)) {
+        // Only continue the search if this.possibleIndexes is undefined,
+        // or if [node.start, node.end) contains at least one possible
+        // index of an identifier that we care about.
         this.visitChildren(path);
       }
     }
+  }
+
+  // Returns true if and only if this.possibleIndexes is defined and
+  // contains any indexes that are >= node.start and < node.end.
+  _nodeContainsPossibleIndex(node) {
+    if (node.type === "File" ||
+        node.type === "Program") {
+      // Always visit File and Program AST nodes, since they're always
+      // near the root of the AST, and they don't have any identifiers of
+      // their own that aren't part of other nodes.
+      return true;
+    }
+
+    const array = this.possibleIndexes;
+    if (! array) {
+      // If this.possibleIndexes is not defined, then we don't know
+      // anything about where to look, so anything goes.
+      return true;
+    }
+
+    const start = node.start;
+    const end = node.end;
+
+    if (typeof start !== "number" ||
+        typeof end !== "number") {
+      // If we don't have start/end for this node, anything goes.
+      return true;
+    }
+
+    let low = 0;
+    let high = array.length;
+
+    while (low < high) {
+      const pos = (low + high) >> 1;
+      if (array[pos] < start) {
+        low = pos + 1;
+      } else {
+        high = pos;
+      }
+    }
+
+    // Set left to the lower bound of a binary search for node.start
+    // within this.possibleIndexes.
+    const left = low;
+
+    high = array.length;
+
+    while (low < high) {
+      const pos = (low + high) >> 1;
+      if (end < array[pos]) {
+        high = pos;
+      } else {
+        low = pos + 1;
+      }
+    }
+
+    // Set right to the upper of a binary search for node.end within
+    // this.possibleIndexes.
+    const right = high;
+
+    // Return true if and only if there were any possible indexes that
+    // were >= node.start and < node.end.
+    return left < right;
   }
 
   visitChildren(path) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -26,20 +26,38 @@ class Visitor {
     this.visitChildren = function (path) {
       visitChildren.call(that, path);
     };
+
+    // Define some internal properties before the constructor returns to
+    // help the JS engine understand the shape of the visitor object.
+    this._beforeReset();
+  }
+
+  _beforeReset() {
+    // Since this.possibleIndexes can cause the traversal to ignore entire
+    // subtrees if misused, it's important to force the reset method to
+    // redefine it each time the visit method is called.
+    this.possibleIndexes = null;
+    this._piLowerBound = 0;
+    this._piUpperBound = 0;
+  }
+
+  _afterReset() {
+    // Reset the bounds we are currently considering within
+    // this.possibleIndexes, so that we can adjust the bounds in
+    // _visitChildrenIfPossible below. This allows us to pretend we're
+    // working with this.possibleIndexes.slice(this._piLowerBound,
+    // this._piUpperBound) without actually modifying the array.
+    if (Array.isArray(this.possibleIndexes)) {
+      this._piUpperBound = this.possibleIndexes.length;
+    }
   }
 
   visit(path) {
+    this._beforeReset();
+    // The user-defined reset method has a chance to (re)initialize any
+    // instance variables, including this.possibleIndexes.
     this.reset.apply(this, arguments);
-
-    const pis = this.possibleIndexes;
-    if (Array.isArray(pis)) {
-      // Just in case a previous visit left this.possibleIndexes in a bad
-      // state, reset our left/right bookkeeping properties. See how these
-      // properties are used in _visitChildrenIfPossible below.
-      pis.left = 0;
-      pis.right = pis.length;
-    }
-
+    this._afterReset();
     this.visitWithoutReset(path);
   }
 
@@ -94,49 +112,48 @@ class Visitor {
       return this.visitChildren(nodePath);
     }
 
-    // Save the current array.{left,right} values so that we can restore
-    // them at the end of this method.
-    const oldLeft = array.left;
-    const oldRight = array.right;
+    // Save the current this._pi{Lower,Upper}Bound values so that we can
+    // restore them at the end of this method.
+    const oldLowerBound = this._piLowerBound;
+    const oldUpperBound = this._piUpperBound;
 
-    let left = typeof oldLeft === "number" ? oldLeft : 0;
-    let right = typeof oldRight === "number" ? oldRight : array.length;
+    let lowerBound = typeof oldLowerBound === "number" ? oldLowerBound : 0;
+    let upperBound = typeof oldUpperBound === "number" ? oldUpperBound : array.length;
 
     // Find the first possible index not less than node.start. While a
     // binary search might seem more efficient here, remember that we are
     // descending a tree of nested AST nodes, with each new [node.start,
     // node.end) interval getting a little smaller at every level. This
     // while loop is responsible for closing the gap since the last time
-    // we updated array.left, which means left will usually only need to
-    // be incremented a small number of times, whereas a binary search for
-    // this lower bound would take log_2(array.length - left) steps.
-    while (left < right &&
-           array[left] < start) {
-      ++left;
+    // we updated the lower bound, which means lowerBound should only need
+    // to be incremented a small number of times, whereas a binary search
+    // would take log_2(array.length - lowerBound) steps.
+    while (lowerBound < upperBound &&
+           array[lowerBound] < start) {
+      ++lowerBound;
     }
 
     // Find the first possible index greater than node.end. Again, a
     // binary search would be more expensive here, since we expect to
-    // decrement right only a small number of times, typically.
-    while (left < right &&
-           end < array[right - 1]) {
-      --right;
+    // decrement upperBound only a small number of times, typically.
+    while (lowerBound < upperBound &&
+           end < array[upperBound - 1]) {
+      --upperBound;
     }
 
-    // Now array.slice(left, right) contains exactly the subsequence of
-    // possible indexes that are in the interval [node.start, node.end).
-    // If that interval is empty, then this node does not contain any of
-    // the indexes we care about, and we can avoid visiting its children.
-    // If the interval is non-empty, we update array.{left,right}, visit
-    // children, then reset array.{left,right} to old{Left,Right}.
-    if (left < right) {
-      array.left = left;
-      array.right = right;
-
+    // Now array.slice(lowerBound, upperBound) contains exactly the
+    // subsequence of possible indexes that are contained by the interval
+    // [node.start, node.end). If that interval is empty, then this node
+    // does not contain any of the indexes we care about, and we can avoid
+    // visiting its children. If the interval is non-empty, first update
+    // this._pi{Lower,Upper}Bound, then visit the children, then reset
+    // this._pi{Lower,Upper}Bound to the old{Upper,Lower}Bound values.
+    if (lowerBound < upperBound) {
+      this._piLowerBound = lowerBound;
+      this._piUpperBound = upperBound;
       this.visitChildren(nodePath);
-
-      array.left = oldLeft;
-      array.right = oldRight;
+      this._piLowerBound = oldLowerBound;
+      this._piUpperBound = oldUpperBound;
     }
   }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -30,6 +30,16 @@ class Visitor {
 
   visit(path) {
     this.reset.apply(this, arguments);
+
+    const pis = this.possibleIndexes;
+    if (Array.isArray(pis)) {
+      // Just in case a previous visit left this.possibleIndexes in a bad
+      // state, reset our left/right bookkeeping properties. See how these
+      // properties are used in _visitChildrenIfPossible below.
+      pis.left = 0;
+      pis.right = pis.length;
+    }
+
     this.visitWithoutReset(path);
   }
 
@@ -42,31 +52,36 @@ class Visitor {
       if (typeof method === "function") {
         // The method must call this.visitChildren(path) to continue traversing.
         method.call(this, path);
-      } else if (this._nodeContainsPossibleIndex(value)) {
+      } else {
         // Only continue the search if this.possibleIndexes is undefined,
         // or if [node.start, node.end) contains at least one possible
         // index of an identifier that we care about.
-        this.visitChildren(path);
+        this._visitChildrenIfPossible(path);
       }
     }
   }
 
-  // Returns true if and only if this.possibleIndexes is defined and
-  // contains any indexes that are >= node.start and < node.end.
-  _nodeContainsPossibleIndex(node) {
-    if (node.type === "File" ||
-        node.type === "Program") {
-      // Always visit File and Program AST nodes, since they're always
-      // near the root of the AST, and they don't have any identifiers of
-      // their own that aren't part of other nodes.
-      return true;
-    }
-
+  // Calls this.visitChildren(nodePath) unless this.possibleIndexes is
+  // defined and we can determine that the current [node.start, node.end)
+  // interval does not contain any of the possible indexes we care about.
+  _visitChildrenIfPossible(nodePath) {
     const array = this.possibleIndexes;
     if (! array) {
       // If this.possibleIndexes is not defined, then we don't know
-      // anything about where to look, so anything goes.
-      return true;
+      // anything about where (not) to look, so err on the side of
+      // visiting the children.
+      return this.visitChildren(nodePath);
+    }
+
+    const node = nodePath.getValue();
+
+    if (node.type === "File" ||
+        node.type === "Program") {
+      // Always visit children of File and Program AST nodes, since
+      // they're always near the root of the AST, and they don't have any
+      // identifiers of their own that aren't part of other nodes, so it
+      // might be awkward to use this.possibleIndexes to include them.
+      return this.visitChildren(nodePath);
     }
 
     const start = node.start;
@@ -74,44 +89,55 @@ class Visitor {
 
     if (typeof start !== "number" ||
         typeof end !== "number") {
-      // If we don't have start/end for this node, anything goes.
-      return true;
+      // If we don't have start/end for this node, err on the side of
+      // visiting the children.
+      return this.visitChildren(nodePath);
     }
 
-    let low = 0;
-    let high = array.length;
+    // Save the current array.{left,right} values so that we can restore
+    // them at the end of this method.
+    const oldLeft = array.left;
+    const oldRight = array.right;
 
-    while (low < high) {
-      const pos = (low + high) >> 1;
-      if (array[pos] < start) {
-        low = pos + 1;
-      } else {
-        high = pos;
-      }
+    let left = typeof oldLeft === "number" ? oldLeft : 0;
+    let right = typeof oldRight === "number" ? oldRight : array.length;
+
+    // Find the first possible index not less than node.start. While a
+    // binary search might seem more efficient here, remember that we are
+    // descending a tree of nested AST nodes, with each new [node.start,
+    // node.end) interval getting a little smaller at every level. This
+    // while loop is responsible for closing the gap since the last time
+    // we updated array.left, which means left will usually only need to
+    // be incremented a small number of times, whereas a binary search for
+    // this lower bound would take log_2(array.length - left) steps.
+    while (left < right &&
+           array[left] < start) {
+      ++left;
     }
 
-    // Set left to the lower bound of a binary search for node.start
-    // within this.possibleIndexes.
-    const left = low;
-
-    high = array.length;
-
-    while (low < high) {
-      const pos = (low + high) >> 1;
-      if (end < array[pos]) {
-        high = pos;
-      } else {
-        low = pos + 1;
-      }
+    // Find the first possible index greater than node.end. Again, a
+    // binary search would be more expensive here, since we expect to
+    // decrement right only a small number of times, typically.
+    while (left < right &&
+           end < array[right - 1]) {
+      --right;
     }
 
-    // Set right to the upper of a binary search for node.end within
-    // this.possibleIndexes.
-    const right = high;
+    // Now array.slice(left, right) contains exactly the subsequence of
+    // possible indexes that are in the interval [node.start, node.end).
+    // If that interval is empty, then this node does not contain any of
+    // the indexes we care about, and we can avoid visiting its children.
+    // If the interval is non-empty, we update array.{left,right}, visit
+    // children, then reset array.{left,right} to old{Left,Right}.
+    if (left < right) {
+      array.left = left;
+      array.right = right;
 
-    // Return true if and only if there were any possible indexes that
-    // were >= node.start and < node.end.
-    return left < right;
+      this.visitChildren(nodePath);
+
+      array.left = oldLeft;
+      array.right = oldRight;
+    }
   }
 
   visitChildren(path) {


### PR DESCRIPTION
When an AST traversal is looking for syntax that contains a known set of identifiers, such as `import` and `export`, we can ignore entire subtrees of the AST that do not contain any possible indexes of those identifiers, for a potentially massive savings in traversal time.

The list of possible indexes can be computed quickly using a regular expression, without actually parsing the code, since it's not the end of the world if there are false positives in the `possibleIndexes` array.

Closes #113, finally! :tada: