### PR TITLE
Create Entry objects before module evaluation in module.link.

### DIFF
--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -13,9 +13,12 @@ var UNDEFINED = {};
 var hasOwn = Object.prototype.hasOwnProperty;
 var keySalt = 0;
 
-function Entry(exported) {
-  // The module.exports of the module this Entry is managing.
-  this.exports = exported;
+function Entry(id) {
+  // The canonical absolute module ID of the module this Entry manages.
+  this.id = id;
+  // The Module object this Entry manages, unknown until module.export or
+  // module.link is called for the first time.
+  this.module = null;
   // Getters for local variables exported from the managed module.
   this.getters = Object.create(null);
   // Setters for assigning to local variables in parent modules.
@@ -23,80 +26,21 @@ function Entry(exported) {
   // The normalized namespace object that importers receive when they use
   // `import * as namespace from "..."` syntax.
   this.namespace = utils.createNamespace();
-  // Map from module.id string to module object for each module this Entry
-  // is managing.
-  this.ownerModules = Object.create(null);
-  // Boolean indicating whether all the modules this Entry is managing
-  // have finished loading yet. Call entry.hasLoaded() to compute.
-  this._loaded = false;
 }
 
 var Ep = utils.setPrototypeOf(Entry.prototype, null);
+var entryMap = Object.create(null);
 
-var weakEntryMap = typeof WeakMap === "function"
-  ? new WeakMap
-  : new (function FakeWeakMap() {
-    // A barely functional WeakMap polyfill, just in case. This
-    // implementation needs to be logically correct only in the specific
-    // ways that the Entry class uses it. It isn't even "weak" in the
-    // garbage-collection sense of the word, but that's fine.
-    var keys = [];
-    var values = [];
+Entry.getOrCreate = function (id, mod) {
+  var entry = hasOwn.call(entryMap, id)
+    ? entryMap[id]
+    : entryMap[id] = new Entry(id);
 
-    this.get = function (obj) {
-      var index = keys.indexOf(obj);
-      if (index >= 0) {
-        return values[index];
-      }
-    };
-
-    this.set = function (obj, value) {
-      var index = keys.indexOf(obj);
-      if (index >= 0) {
-        values[index] = value;
-      } else {
-        keys.push(obj);
-        values.push(value);
-      }
-    };
-  });
-
-Entry.get = function (exported) {
-  if (utils.isObjectLike(exported)) {
-    var entry = weakEntryMap.get(exported);
-    if (entry !== void 0) {
-      return entry;
-    }
-  }
-  return null;
-};
-
-Entry.getOrCreate = function (exported, mod) {
-  var entry = getOrCreate(exported);
-
-  if (utils.isObject(mod)) {
-    entry.ownerModules[mod.id] = mod;
+  if (utils.isObject(mod) &&
+      mod.id === entry.id) {
+    entry.module = mod;
   }
 
-  return entry;
-};
-
-function getOrCreate(exported) {
-  if (! utils.isObjectLike(exported)) {
-    // In case the child module modified module.exports, create a temporary
-    // Entry object so that we can call the entry.addSetters method once,
-    // which will trigger entry.runSetters(names), so that module.importSync
-    // behaves as expected.
-    return new Entry(exported);
-  }
-
-  var entry = weakEntryMap.get(exported);
-  if (entry !== void 0) {
-    return entry;
-  }
-
-  var entry = new Entry(exported);
-  weakEntryMap.set(exported, entry);
   return entry;
 };
 
@@ -218,7 +162,7 @@ Ep.runGetters = function (names) {
     // calls remain consistent with module.watch.
     if (value !== GETTER_ERROR) {
       this.namespace[name] = value;
-      this.exports[name] = value;
+      this.module.exports[name] = value;
     }
   }
 };
@@ -226,60 +170,37 @@ Ep.runGetters = function (names) {
 function syncExportsToNamespace(entry, names) {
   var setDefault = false;
 
-  if (! utils.getESModule(entry.exports)) {
+  if (entry.module === null) return;
+  var exports = entry.module.exports;
+
+  if (! utils.getESModule(exports)) {
     // If the module entry is managing overrides module.exports, that
     // value should be exposed as the .default property of the namespace,
     // unless module.exports is marked as an ECMASCript module.
-    entry.namespace.default = entry.exports;
+    entry.namespace.default = exports;
     setDefault = true;
   }
 
-  if (! utils.isObjectLike(entry.exports)) {
+  if (! utils.isObjectLike(exports)) {
     return;
   }
 
   if (names === void 0 ||
       names.indexOf("*") >= 0) {
-    names = Object.keys(entry.exports);
+    names = Object.keys(exports);
   }
 
   names.forEach(function (key) {
     // Don't set any properties for which a getter function exists in
     // entry.getters, don't accidentally override entry.namespace.default,
-    // and only copy own properties from entry.exports.
+    // and only copy own properties from entry.module.exports.
     if (! hasOwn.call(entry.getters, key) &&
         ! (setDefault && key === "default") &&
-        hasOwn.call(entry.exports, key)) {
-      utils.copyKey(key, entry.namespace, entry.exports);
+        hasOwn.call(exports, key)) {
+      utils.copyKey(key, entry.namespace, exports);
     }
   });
 }
-
-// Called by module.runSetters once the module this Entry is managing has
-// finished loading.
-Ep.hasLoaded = function () {
-  if (this._loaded) {
-    return true;
-  }
-
-  var ids = Object.keys(this.ownerModules);
-  var idCount = ids.length;
-
-  for (var i = 0; i < idCount; ++i) {
-    var owner = this.ownerModules[ids[i]];
-    if (! owner.loaded && owner.exports === this.exports) {
-      // At least one owner module whose exports are still ===
-      // this.exports has not finished loading, so this this Entry cannot
-      // be marked as loaded yet.
-      return false;
-    }
-  }
-
-  // Set entry._loaded = true only if all the modules in
-  // entry.ownerModules that are still associated with entry.exports have
-  // finished loading.
-  return this._loaded = true;
-};
 
 // Called whenever module.exports might have changed, to trigger any
 // setters associated with the newly exported values. The names parameter
@@ -320,7 +241,7 @@ Ep.runSetters = function (names) {
     // bookkeeping above, the runSetters broadcast will only proceed
     // as far as there are any actual changes to report.
     var parent = parents[parentIDs[i]];
-    var parentEntry = Entry.get(parent.exports);
+    var parentEntry = entryMap[parent.id];
     if (parentEntry) {
       parentEntry.runSetters();
     }
@@ -430,7 +351,7 @@ function forEachSetter(entry, names, callback) {
         // can forget the corresponding setter, because we've already
         // reported that constant value. Note that we can't forget the
         // getter, because we need to remember the original value in case
-        // anyone tampers with entry.exports[name].
+        // anyone tampers with entry.module.exports[name].
         delete setters[key];
       }
     }
@@ -446,19 +367,20 @@ function getExportByName(entry, name) {
     return entry.namespace[name];
   }
 
-  var exported = entry.exports;
+  if (entry.module === null) return;
+  var exports = entry.module.exports;
 
   if (name === "default" &&
-      ! (utils.getESModule(exported) &&
-         "default" in exported)) {
-    return exported;
+      ! (utils.getESModule(exports) &&
+         "default" in exports)) {
+    return exports;
   }
 
-  if (exported == null) {
+  if (exports == null) {
     return;
   }
 
-  return exported[name];
+  return exports[name];
 }
 
 function makeUniqueKey() {

--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -12,9 +12,12 @@ var Entry = require("./entry.js");
 // specific module objects, or for Module.prototype (where implemented),
 // to make the runtime available throughout the entire module system.
 exports.enable = function (mod) {
+  if (typeof mod.resolve !== "function") {
+    throw new Error("module.resolve not implemented");
+  }
+
   if (mod.link !== moduleLink) {
     mod.link = moduleLink;
-    mod.watch = moduleWatch;
     mod["export"] = moduleExport;
     mod.exportDefault = moduleExportDefault;
     mod.exportAs = moduleExportAs;
@@ -29,27 +32,37 @@ exports.enable = function (mod) {
   return false;
 };
 
-// Shorthand for module.watch(require(id), setters) that accepts just a
-// string module identifier `id` rather than the exports object for the
-// required module. In the future, this API will replace module.watch, and
-// will allow for creating Entry objects before module evaluation, which
-// will solve some problems with import cycles and hoisted declarations.
+// Calling module.link(id, setters) resolves the given ID using
+// module.resolve(id), which should return a canonical absolute module
+// identifier string (like require.resolve); then creates an Entry object
+// for the child module and evaluates its code (if this is the first time
+// it has been imported) by calling module.require(id). Finally, the
+// provided setter functions will be called with values exported by the
+// module, possibly multiple times when/if those exported values change.
+// The module.link name is intended to evoke the "liveness" of the
+// exported bindings, since we are subscribing to all future exports of
+// the child module, not just taking a snapshot of its current exports.
 function moduleLink(id, setters, key) {
-  return moduleWatch.call(this, this.require(id), setters, key);
-}
-
-// If key is provided, it will be used to identify the given setters so
-// that they can be replaced if module.watch is called again with the same
-// key. This avoids potential memory leaks from import declarations inside
-// loops. The compiler generates these keys automatically (and
-// deterministically) when compiling nested import declarations.
-function moduleWatch(exported, setters, key) {
   utils.setESModule(this.exports);
-  Entry.getOrCreate(this.exports, this);
+  Entry.getOrCreate(this.id, this);
+
+  var absChildId = this.resolve(id);
+  var childEntry = Entry.getOrCreate(absChildId);
 
   if (utils.isObject(setters)) {
-    Entry.getOrCreate(exported).addSetters(this, setters, key);
+    childEntry.addSetters(this, setters, key);
   }
+
+  var exports = this.require(absChildId);
+
+  if (childEntry.module === null) {
+    childEntry.module = {
+      id: absChildId,
+      exports: exports
+    };
+  }
+
+  childEntry.runSetters();
 }
 
 // Register getter functions for local variables in the scope of an export
@@ -57,7 +70,7 @@ function moduleWatch(exported, setters, key) {
 // functions always return the same values.
 function moduleExport(getters, constant) {
   utils.setESModule(this.exports);
-  var entry = Entry.getOrCreate(this.exports, this);
+  var entry = Entry.getOrCreate(this.id, this);
   entry.addGetters(getters, constant);
   if (this.loaded) {
     // If the module has already been evaluated, then we need to trigger
@@ -77,12 +90,11 @@ function moduleExportDefault(value) {
 }
 
 // Returns a function suitable for passing as a setter callback to
-// module.watch or module.link. If name is an identifier, calling the
-// function will set the export of that name to the given value. If the
-// name is "*", all properties of the value object will be exported by
-// name, except for "default" (use "*+" instead of "*" to include it).
-// Discussion of why the "default" property is skipped:
-// https://github.com/tc39/ecma262/issues/948
+// module.link. If name is an identifier, calling the function will set
+// the export of that name to the given value. If the name is "*", all
+// properties of the value object will be exported by name, except for
+// "default" (use "*+" instead of "*" to include it). Why the "default"
+// property is skipped: https://github.com/tc39/ecma262/issues/948
 function moduleExportAs(name) {
   var entry = this;
   var includeDefault = name === "*+";
@@ -104,17 +116,7 @@ function moduleExportAs(name) {
 // might happen more than once per module, in case of dependency cycles,
 // so we want Module.prototype.runSetters to run each time.
 function runSetters(valueToPassThrough) {
-  var entry = Entry.get(this.exports);
-  if (entry !== null) {
-    entry.runSetters();
-  }
-
-  if (this.loaded) {
-    // If this module has finished loading, then we must create an Entry
-    // object here, so that we can add this module to entry.ownerModules
-    // by passing it as the second argument to Entry.getOrCreate.
-    Entry.getOrCreate(this.exports, this);
-  }
+  Entry.getOrCreate(this.id, this).runSetters();
 
   // Assignments to exported local variables get wrapped with calls to
   // module.runSetters, so module.runSetters returns the

--- a/node/index.js
+++ b/node/index.js
@@ -2,6 +2,11 @@
 
 const runtime = require("../lib/runtime");
 const setDefaults = require("../lib/options").setDefaults;
+const Module = module.constructor;
+
+Module.prototype.resolve = function (id) {
+  return Module._resolveFilename(id, this);
+};
 
 let isDefaultsSet = false;
 const parentModule = module.parent || __non_webpack_module__.parent;

--- a/test/hoisting-tests.js
+++ b/test/hoisting-tests.js
@@ -1,0 +1,10 @@
+import assert from "assert";
+
+describe("hoisted function declarations", () => {
+  it("should be accessible before evaluation finishes", () => {
+    import { a } from "./hoisting/a.js";
+    import { b } from "./hoisting/b.js";
+    assert.strictEqual(a(), b);
+    assert.strictEqual(b(), a);
+  });
+});

--- a/test/hoisting/a.js
+++ b/test/hoisting/a.js
@@ -1,0 +1,10 @@
+import assert from "assert";
+import { b } from "./b.js";
+
+assert.strictEqual(a(), b);
+assert.strictEqual(typeof b, "function");
+assert.strictEqual(b(), a);
+
+export function a() {
+  return b;
+}

--- a/test/hoisting/b.js
+++ b/test/hoisting/b.js
@@ -1,0 +1,10 @@
+import assert from "assert";
+import { a } from "./a.js";
+
+assert.strictEqual(b(), a);
+assert.strictEqual(typeof a, "function");
+assert.strictEqual(a(), b);
+
+export function b() {
+  return a;
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,3 +8,4 @@ import "./file-extension-tests.js";
 import "./transform-tests.js";
 import "./babel-plugin-tests.js";
 import "./repl-tests.js";
+import "./hoisting-tests.js";


### PR DESCRIPTION
With this commit, the Reify runtime no longer stores `Entry` objects on the `module.exports` object, but instead keeps them in a global map, keyed by absolute module identifiers.

By creating `Entry` objects before evaluating the corresponding modules, it's possible for modules involved in dependency cycles to access each other's `Entry` objects before they have finished evaluating, which allows sharing of hoisted function declarations, as required by the ECMA-262 specification.

Although it was previously possible to implement `module.link` in terms of `module.watch`, it is no longer possible to support `module.watch`, since it has no way of resolving the absolute module identifier of the child module, and thus cannot correctly populate the `Entry` map.

This commit essentially reverts PR #155, which abandoned an earlier global `Entry` map in favor of storing Entry objects on `module.exports`. At the time, I thought using `module.exports` would be simpler, in part because it made CommonJS "bridge" modules work:

```js
module.exports = require("./some/other/module");
```

Since then, however, we have accumulated a number of hacks to compensate for edge cases that I did not foresee, which is why this commit is clearly a simplification of the runtime implementation.

If you want the `module.exports` of one module to reflect the exports of another module (including the `default` export), the correct way to do that is now

```js
module.link("./some/other/module", { "*", "*+"});
```