### PR TITLE
Support compiling dynamic import(...).

### DIFF
--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -127,6 +127,12 @@ class ImportExportVisitor extends Visitor {
     this.sourceType = getOption(options, "sourceType");
     this.moduleAlias = getOption(options, "moduleAlias");
     this.possibleIndexes = getOption(options, "possibleIndexes");
+    const di = this.dynamicImport = getOption(options, "dynamicImport");
+    if (di && typeof di !== "string") {
+      // If someone passes { dynamicImport: true }, use module.dynamicImport
+      // by default.
+      this.dynamicImport = "dynamicImport";
+    }
   }
 
   visitProgram(path) {
@@ -174,6 +180,18 @@ class ImportExportVisitor extends Visitor {
     );
 
     hoistImports(this, path, hoistedCode);
+  }
+
+  visitImport(path) {
+    if (this.dynamicImport) {
+      const importCallee = path.getValue();
+      const replacement = this.moduleAlias + "." + this.dynamicImport;
+      overwrite(this, importCallee.start, importCallee.end, replacement);
+      if (this.modifyAST) {
+        path.replace(this.parse(replacement));
+      }
+      this.madeChanges = true;
+    }
   }
 
   visitExportAllDeclaration(path) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -10,6 +10,7 @@ const defaultOptions = {
   generateLetDeclarations: false,
   sourceType: "unambiguous",
   moduleAlias: "module",
+  dynamicImport: false,
   get parse () {
     return require("./parsers/default.js").parse;
   }

--- a/lib/parsers/acorn.js
+++ b/lib/parsers/acorn.js
@@ -1,6 +1,9 @@
 "use strict";
 
-const acorn = require("acorn");
+const Parser = require("acorn").Parser.extend(
+  require("acorn-dynamic-import").default
+);
+
 const acornExtensions = require("./acorn-extensions");
 
 exports.options = {
@@ -12,7 +15,7 @@ exports.options = {
 };
 
 function parse(code) {
-  const parser = new acorn.Parser(exports.options, code);
+  const parser = new Parser(exports.options, code);
   acornExtensions.enableAll(parser);
   return parser.parse();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -761,6 +761,11 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
       "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
+    "acorn-dynamic-import": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "acorn": "^6.1.1",
+    "acorn-dynamic-import": "^4.0.0",
     "semver": "^5.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Passing `{ dynamicImport: true }` to the compiler will transform `import(...)` to `module.dynamicImport(...)`. Passing a string instead of `true` will use that string as the method, instead of `dynamicImport`. If the `dynamicImport` option is not provided, `import(...)` expressions will remain untouched.