### PR TITLE
Rename module identifier by wrapping program.body with IIFE.

### DIFF
--- a/lib/assignment-visitor.js
+++ b/lib/assignment-visitor.js
@@ -87,7 +87,7 @@ function wrap(visitor, path) {
         type: "MemberExpression",
         object: {
           type: "Identifier",
-          name: "module"
+          name: visitor.moduleAlias,
         },
         property: {
           type: "Identifier",

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -49,7 +49,7 @@ exports.compile = function (code, options) {
   }
 
   const rootPath = new FastPath(result.ast || parse(code));
-  options.moduleAlias = makeUniqueId(getOption(options, "moduleAlias"), code);
+  options.moduleAlias = getOption(options, "moduleAlias");
   importExportVisitor.visit(rootPath, code, options);
 
   const magicString = importExportVisitor.magicString;

--- a/lib/import-export-visitor.js
+++ b/lib/import-export-visitor.js
@@ -38,12 +38,6 @@ class ImportExportVisitor extends Visitor {
         }
       }
 
-      if (bodyInfo.parent.type === "Program" &&
-          this.moduleAlias !== "module") {
-        codeToInsert += this.generateLetDeclarations ? "const " : "var ";
-        codeToInsert += this.moduleAlias + "=module;";
-      }
-
       const addExportsMap = (map, constant) => {
         const namedExports = toModuleExport(this, map, constant);
         if (namedExports) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -25,6 +25,7 @@ module.exports = function (ast, options) {
   if (importExportVisitor.madeChanges) {
     assignmentVisitor.visit(rootPath, {
       exportedLocalNames: importExportVisitor.exportedLocalNames,
+      moduleAlias: importExportOptions.moduleAlias,
       modifyAST: true
     });
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -41,6 +41,9 @@ class Visitor {
     this._piUpperBound = 0;
   }
 
+  // The reset method does nothing unless it is overridden.
+  reset() {}
+
   _afterReset() {
     // Reset the bounds we are currently considering within
     // this.possibleIndexes, so that we can adjust the bounds in

--- a/package-lock.json
+++ b/package-lock.json
@@ -603,6 +603,18 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+      "integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@babel/core": "7.4.4",
     "@babel/parser": "7.4.4",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "7.4.4",
     "lodash": "4.17.11",
     "mocha": "6.1.4",

--- a/test/compiler-tests.js
+++ b/test/compiler-tests.js
@@ -32,12 +32,6 @@ describe("compiler", () => {
     assert.ok(/unexpected/i.test(error.message));
   });
 
-  it("should choose a unique module identifier", () => {
-    const module = null, module2 = null;
-    import { a } from "./misc/abc";
-    assert.strictEqual(a, "a");
-  });
-
   it("should be enabled for packages that depend on reify", () => {
     import a from "enabled";
     assert.strictEqual(a, assert);

--- a/test/output/export-multi-namespace/expected.js
+++ b/test/output/export-multi-namespace/expected.js
@@ -1,1 +1,1 @@
-"use strict";var module1=module;module1.link("module",{"*":["a","b"]},0);
+"use strict";module.link("module",{"*":["a","b"]},0);

--- a/test/output/name/expected.js
+++ b/test/output/name/expected.js
@@ -1,4 +1,4 @@
-"use strict";var module1=module;module1.export({foo:()=>foo});module1.export({id:()=>id,name:()=>name},true);const path = require("path");
+"use strict";module.export({foo:()=>foo});module.export({id:()=>id,name:()=>name},true);const path = require("path");
 
 const id = module.id,
   name = path.basename(__filename);

--- a/test/output/only-nested/expected.js
+++ b/test/output/only-nested/expected.js
@@ -1,3 +1,3 @@
-"use strict";var module1=module;function f() {var a,c;module1.link("./module",{a(v){a=v},b(v){c=v}},0);
+"use strict";function f() {var a,c;module.link("./module",{a(v){a=v},b(v){c=v}},0);
 
 }


### PR DESCRIPTION
Before this change, in order to obtain a reliable reference to the original `module` object, the Reify compiler would inject a variable declaration at the beginning of the generated code that bound some other (uniquely named) variable to the `module` object, and then that unique variable was used in all the other Reify-generated expressions, such as `module1.export(...)` and `module1.link(...)`.

The trouble with this strategy was that the injected variable declaration could still collide with other declarations in the module scope that involve the `module` identifer.

A better way to solve that problem is to introduce another scope by wrapping the module code in an immediately invoked function expression. The original `module` object can be passed as an argument to that function, and the corresponding parameter can be uniquely named:
```js
(function (module1) {
  module1.export({ name: () => name });
  module1.link("some-module", ...);
  // ...
}).call(this, module);
```

However, this wrapping should happen as late as possible, in some cases after multiple invocations of the Reify compiler, so the wrapping should not be the responsibility of the Reify compiler itself. Instead, the compiler should just use whatever `options.moduleAlias` is passed in, and not second-guess it or attempt to inject any variable bindings.

In this PR, the Babel plugin (`reify/plugins/babel`) becomes responsible for the IIFE wrapping shown above, while also gaining the ability to transform the AST twice: upon entering _and_ upon exiting the `Program` AST node. This double transformation is necessary to transform both `import` and `export` declarations found in the source code, and those that were injected later by other transforms, such as `@babel/plugin-transform-runtime`.