### PR TITLE
Fix performance problem from throwing/catching lots of exceptions

### DIFF
--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -393,6 +393,7 @@ function makeUniqueKey() {
 
 function runGetter(entry, name) {
   var getter = entry.getters[name];
+  if (!getter) return GETTER_ERROR;
   try {
     var result = getter();
     ++getter.runCount;


### PR DESCRIPTION
`runGetter` is an inner-loop function that gets called every time anything is imported, and it showed up as a hotspot (~150ms) in my browser Javascript profiler results. Turns out, `getter` is sometimes null, which means that the small `try`/`catch` block here generates and consumes a null-reference exception. This is slow, much slower than handling the null case directly. Doing this reduces the time spent in this function to a much more reasonable ~30ms.