### PR TITLE
Optimizations

### DIFF
--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -259,7 +259,7 @@ Ep.runSetters = function (names, runNsSetter) {
     setter(value, name);
   }
 
-  forEachSetter(this, names, undefined, runSetter);
+  forEachSetter(this, names, void 0, runSetter);
 
   if (this._uninitializedSetters.length > 0) {
     var initNames = [];

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -26,6 +26,9 @@ function Entry(id) {
   // The normalized namespace object that importers receive when they use
   // `import * as namespace from "..."` syntax.
   this.namespace = utils.createNamespace();
+
+  this._lastValues = Object.create(null);
+  this._uninitializedSetters = [];
 }
 
 var Ep = utils.setPrototypeOf(Entry.prototype, null);
@@ -98,6 +101,12 @@ Ep.addSetters = function (parent, setters, key) {
         entry.setters[name] = Object.create(null);
       }
       entry.setters[name][key] = setter;
+
+      this._uninitializedSetters.push({
+        name: name,
+        key: key,
+        setter: setter
+      });
     }
   }
 
@@ -214,7 +223,8 @@ Ep.runSetters = function (names) {
   // module objects whose setters we might need to run.
   var parents;
 
-  forEachSetter(this, names, function (setter, name, value) {
+
+  function runSetter(setter, name, value) {
     if (parents === void 0) {
       parents = Object.create(null);
     }
@@ -223,7 +233,23 @@ Ep.runSetters = function (names) {
     // The param order for setters is `value` then `name` because the `name`
     // param is only used by namespace exports.
     setter(value, name);
-  });
+  }
+
+  forEachSetter(this, names, undefined, runSetter);
+
+  if (this._uninitializedSetters.length > 0) {
+    var initNames = [];
+    var initKeys = [];
+    this._uninitializedSetters.forEach(function (config) {
+      if (config.setter.initialized) {
+        return;
+      }
+      initNames.push(config.name);
+      initKeys.push(config.key);
+    });
+    this._uninitializedSetters.length = 0;
+    forEachSetter(this, initNames, initKeys, runSetter);
+  }
 
   if (! parents) {
     return;
@@ -254,64 +280,32 @@ function callSetterIfNecessary(setter, name, value, callback) {
     return;
   }
 
-  var shouldCall = false;
+  setter.initialized = true;
+  return callback(setter, name, value);
+}
 
-  if (setter.last === void 0) {
-    setter.last = Object.create(null);
-    // Always call the setter if it has never been called before.
-    shouldCall = true;
+function changed(last, prop, value) {
+  var valueToCompare = value;
+  if (valueToCompare !== valueToCompare) {
+    valueToCompare = NAN;
+  } else if (valueToCompare === void 0) {
+    valueToCompare = UNDEFINED;
   }
 
-  function changed(name, value) {
-    var valueToCompare = value;
-    if (valueToCompare !== valueToCompare) {
-      valueToCompare = NAN;
-    } else if (valueToCompare === void 0) {
-      valueToCompare = UNDEFINED;
-    }
-
-    if (setter.last[name] === valueToCompare) {
-      return false;
-    }
-
-    setter.last[name] = valueToCompare;
-    return true;
+  if (last[prop] === valueToCompare) {
+    return false;
   }
 
-  if (name === "*") {
-    var keys = safeKeys(value);
-    var keyCount = keys.length;
-    for (var i = 0; i < keyCount; ++i) {
-      var key = keys[i];
-      // Evaluating value[key] is risky because the property might be
-      // defined by a getter function that logs a deprecation warning (or
-      // worse) when evaluated. For example, Node uses this trick to
-      // display a deprecation warning whenever crypto.createCredentials
-      // is accessed. Fortunately, when value[key] is defined by a getter
-      // function, it's enough to check whether the getter function itself
-      // has changed, since we are careful elsewhere to preserve getters
-      // rather than prematurely evaluating them.
-      if (changed(key, utils.valueOrGetter(value, key))) {
-        shouldCall = true;
-      }
-    }
-  } else if (changed(name, value)) {
-    shouldCall = true;
-  }
-
-  if (shouldCall) {
-    // Only invoke the callback if we have not called this setter
-    // (with a value of this name) before, or the current value is
-    // different from the last value we passed to this setter.
-    return callback(setter, name, value);
-  }
+  last[prop] = valueToCompare;
+  return true;
 }
 
 // Invoke the given callback once for every (setter, name, value) that needs to
 // be called. Note that forEachSetter does not call any setters itself, only the
 // given callback.
-function forEachSetter(entry, names, callback) {
+function forEachSetter(entry, names, keys, callback) {
   var needToCheckNames = true;
+  var keysProvided = keys !== void 0;
 
   if (names === void 0) {
     names = Object.keys(entry.setters);
@@ -328,13 +322,58 @@ function forEachSetter(entry, names, callback) {
       continue;
     }
 
+    var value = getExportByName(entry, name);
+    var shouldCall = false;
+
+    if (!hasOwn.call(entry._lastValues, name)) {
+      entry._lastValues[name] = Object.create(null);
+    }
+
+    var last = entry._lastValues[name];
+
+    if (!shouldCall && name === "*") {
+      var keysToCheck = safeKeys(value);
+      var keyCount = keysToCheck.length;
+      for (var x = 0; x < keyCount; ++x) {
+        var key = keysToCheck[x];
+        // Evaluating value[key] is risky because the property might be
+        // defined by a getter function that logs a deprecation warning (or
+        // worse) when evaluated. For example, Node uses this trick to
+        // display a deprecation warning whenever crypto.createCredentials
+        // is accessed. Fortunately, when value[key] is defined by a getter
+        // function, it's enough to check whether the getter function itself
+        // has changed, since we are careful elsewhere to preserve getters
+        // rather than prematurely evaluating them.
+        if (changed(last, key, utils.valueOrGetter(value, key))) {
+          shouldCall = true;
+        }
+      }
+    } else if (!shouldCall && changed(last, name, value)) {
+      shouldCall = true;
+    }
+
+    // Only invoke the callback if the current value is
+    // different from the last value we passed to this setter.
+    // If we need to run setters for the first time even if the value didn't change,
+    // their keys should be provided to force them to be called
+    if (!shouldCall && !keysProvided) {
+      continue;
+    }
+
     var setters = entry.setters[name];
-    var keys = Object.keys(setters);
+    if (!keysProvided) {
+      keys = Object.keys(setters);
+    }
+
     var keyCount = keys.length;
 
     for (var j = 0; j < keyCount; ++j) {
       var key = keys[j];
-      var value = getExportByName(entry, name);
+
+      if (keysProvided &&
+        !hasOwn.call(setters, key)) {
+        continue;
+      }
 
       callSetterIfNecessary(setters[key], name, value, callback);
 

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -337,6 +337,16 @@ function forEachSetter(entry, names, callback) {
     var settersByKey = entry.setters[name];
     if (!settersByKey) return;
 
+    var getter = entry.getters[name];
+    var alreadyCalledConstantGetter =
+      typeof getter === "function" &&
+      // Sometimes a getter function will throw because it's called
+      // before the variable it's supposed to return has been
+      // initialized, so we need to know that the getter function has
+      // run to completion at least once.
+      getter.runCount > 0 &&
+      getter.constant;
+
     var value = getExportByName(entry, name);
 
     // Although we may have multiple setter functions with different keys in
@@ -360,21 +370,13 @@ function forEachSetter(entry, names, callback) {
         // Invoke the setter function with the updated value.
         callback(setter, name, value);
 
-        // TODO Refactor this out of the settersByKey loop, if possible.
-        var getter = entry.getters[name];
-        if (typeof getter === "function" &&
-            // Sometimes a getter function will throw because it's called
-            // before the variable it's supposed to return has been
-            // initialized, so we need to know that the getter function has
-            // run to completion at least once.
-            getter.runCount > 0 &&
-            getter.constant) {
-          // If we happen to know that this getter function has run
-          // successfully, and will never return a different value, then we
-          // can forget the corresponding setter, because we've already
-          // reported that constant value. Note that we can't forget the
-          // getter, because we need to remember the original value in case
-          // anyone tampers with entry.module.exports[name].
+        if (alreadyCalledConstantGetter) {
+          // If we happen to know this getter function has run successfully
+          // (getter.runCount > 0), and will never return a different value
+          // (getter.constant), then we can forget the corresponding setter,
+          // because we've already reported that constant value. Note that we
+          // can't forget the getter, because we need to remember the original
+          // value in case anyone tampers with entry.module.exports[name].
           delete settersByKey[key];
         }
       }

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -214,21 +214,45 @@ function syncExportsToNamespace(entry, names) {
 // Called whenever module.exports might have changed, to trigger any
 // setters associated with the newly exported values. The names parameter
 // is optional; without it, all getters and setters will run.
-Ep.runSetters = function (names) {
+// If the '*' setter needs to be run, but not the '*' getter (names includes
+// all exports/getters that changed), the runNsSetter option can be enabled.
+Ep.runSetters = function (names, runNsSetter) {
   // Make sure entry.namespace and module.exports are up to date before we
   // call getExportByName(entry, name).
   this.runGetters(names);
 
+  if (runNsSetter && names !== void 0) {
+    names.push('*');
+  }
+
   // Lazily-initialized object mapping parent module identifiers to parent
   // module objects whose setters we might need to run.
   var parents;
-
+  var parentNames;
 
   function runSetter(setter, name, value) {
     if (parents === void 0) {
       parents = Object.create(null);
     }
-    parents[setter.parent.id] = setter.parent;
+    if (parentNames === void 0) {
+      parentNames = Object.create(null);
+    }
+
+    var parentId = setter.parent.id;
+
+    // When setters use the shorthand for re-exporting values, we know
+    // which exports in the parent module were modified, and can do less work
+    // when running the parent setters.
+    // parentNames[parentId] is set to false if there are any setters that we do
+    // not know which exports they modify
+    if (setter.exportAs !== void 0 && parentNames[parentId] !== false) {
+      parentNames[parentId] = parentNames[parentId] || [];
+      parentNames[parentId].push(setter.exportAs);
+    } else if (parentNames[parentId] !== false) {
+      parentNames[parentId] = false;
+    }
+
+    parents[parentId] = setter.parent;
 
     // The param order for setters is `value` then `name` because the `name`
     // param is only used by namespace exports.
@@ -269,7 +293,10 @@ Ep.runSetters = function (names) {
     var parent = parents[parentIDs[i]];
     var parentEntry = entryMap[parent.id];
     if (parentEntry) {
-      parentEntry.runSetters();
+      parentEntry.runSetters(
+        parentNames[parentIDs[i]] || void 0,
+        !!parentNames[parentIDs[i]]
+      );
     }
   }
 };

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -29,7 +29,6 @@ function Entry(id) {
   // Map from local names to snapshots of the corresponding local values, used
   // to determine when local values have changed and need to be re-broadcast.
   this.snapshots = Object.create(null);
-  this._uninitializedSetters = [];
 }
 
 var Ep = utils.setPrototypeOf(Entry.prototype, null);
@@ -102,12 +101,6 @@ Ep.addSetters = function (parent, setters, key) {
         entry.setters[name] = Object.create(null);
       }
       entry.setters[name][key] = setter;
-
-      this._uninitializedSetters.push({
-        name: name,
-        key: key,
-        setter: setter
-      });
     }
   }
 
@@ -231,10 +224,11 @@ Ep.runSetters = function (names, runNsSetter) {
   var parents;
   var parentNames;
 
-  function runSetter(setter, name, value) {
+  forEachSetter(this, names, function (setter, name, value) {
     if (parents === void 0) {
       parents = Object.create(null);
     }
+
     if (parentNames === void 0) {
       parentNames = Object.create(null);
     }
@@ -258,25 +252,7 @@ Ep.runSetters = function (names, runNsSetter) {
     // The param order for setters is `value` then `name` because the `name`
     // param is only used by namespace exports.
     setter(value, name);
-  }
-
-  forEachSetter(this, names, runSetter);
-
-  if (this._uninitializedSetters.length > 0) {
-    var initNames = [];
-    var initKeys = [];
-    this._uninitializedSetters.forEach(function (config) {
-      // The presence of setter.snapshot implies this setter has already
-      // received at least one value, and is thus no longer uninitialized.
-      if (config.setter.snapshot) {
-        return;
-      }
-      initNames.push(config.name);
-      initKeys.push(config.key);
-    });
-    this._uninitializedSetters.length = 0;
-    forEachSetter(this, initNames, runSetter);
-  }
+  });
 
   if (! parents) {
     return;

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -26,8 +26,9 @@ function Entry(id) {
   // The normalized namespace object that importers receive when they use
   // `import * as namespace from "..."` syntax.
   this.namespace = utils.createNamespace();
-
-  this._lastValues = Object.create(null);
+  // Map from local names to snapshots of the corresponding local values, used
+  // to determine when local values have changed and need to be re-broadcast.
+  this.snapshots = Object.create(null);
   this._uninitializedSetters = [];
 }
 
@@ -259,20 +260,22 @@ Ep.runSetters = function (names, runNsSetter) {
     setter(value, name);
   }
 
-  forEachSetter(this, names, void 0, runSetter);
+  forEachSetter(this, names, runSetter);
 
   if (this._uninitializedSetters.length > 0) {
     var initNames = [];
     var initKeys = [];
     this._uninitializedSetters.forEach(function (config) {
-      if (config.setter.initialized) {
+      // The presence of setter.snapshot implies this setter has already
+      // received at least one value, and is thus no longer uninitialized.
+      if (config.setter.snapshot) {
         return;
       }
       initNames.push(config.name);
       initKeys.push(config.key);
     });
     this._uninitializedSetters.length = 0;
-    forEachSetter(this, initNames, initKeys, runSetter);
+    forEachSetter(this, initNames, runSetter);
   }
 
   if (! parents) {
@@ -301,127 +304,106 @@ Ep.runSetters = function (names, runNsSetter) {
   }
 };
 
-function callSetterIfNecessary(setter, name, value, callback) {
-  if (name === "__esModule") {
-    // Ignore setters asking for module.exports.__esModule.
-    return;
+function updateSnapshot(entry, name, newValue) {
+  var newSnapshot = Object.create(null);
+  var newKeys = [];
+
+  if (name === "*") {
+    safeKeys(newValue).forEach(keyOfValue => {
+      // Evaluating value[key] is risky because the property might be
+      // defined by a getter function that logs a deprecation warning (or
+      // worse) when evaluated. For example, Node uses this trick to display
+      // a deprecation warning whenever crypto.createCredentials is
+      // accessed. Fortunately, when value[key] is defined by a getter
+      // function, it's enough to check whether the getter function itself
+      // has changed, since we are careful elsewhere to preserve getters
+      // rather than prematurely evaluating them.
+      newKeys.push(keyOfValue);
+      newSnapshot[keyOfValue] = normalizeSnapshotValue(
+        utils.valueOrGetter(newValue, keyOfValue)
+      );
+    });
+  } else {
+    newKeys.push(name);
+    newSnapshot[name] = normalizeSnapshotValue(newValue);
   }
 
-  setter.initialized = true;
-  return callback(setter, name, value);
+  var oldSnapshot = entry.snapshots[name];
+  if (
+    oldSnapshot &&
+    newKeys.every(key => oldSnapshot[key] === newSnapshot[key]) &&
+    newKeys.length === Object.keys(oldSnapshot).length
+  ) {
+    return oldSnapshot;
+  }
+
+  return entry.snapshots[name] = newSnapshot;
 }
 
-function changed(last, prop, value) {
-  var valueToCompare = value;
-  if (valueToCompare !== valueToCompare) {
-    valueToCompare = NAN;
-  } else if (valueToCompare === void 0) {
-    valueToCompare = UNDEFINED;
-  }
-
-  if (last[prop] === valueToCompare) {
-    return false;
-  }
-
-  last[prop] = valueToCompare;
-  return true;
+function normalizeSnapshotValue(value) {
+  if (value === void 0) return UNDEFINED;
+  if (value !== value && isNaN(value)) return NAN;
+  return value;
 }
 
 // Invoke the given callback once for every (setter, name, value) that needs to
 // be called. Note that forEachSetter does not call any setters itself, only the
 // given callback.
-function forEachSetter(entry, names, keys, callback) {
-  var needToCheckNames = true;
-  var keysProvided = keys !== void 0;
-
+function forEachSetter(entry, names, callback) {
   if (names === void 0) {
     names = Object.keys(entry.setters);
-    needToCheckNames = false;
   }
 
-  var nameCount = names.length;
+  names.forEach(name => {
+    // Ignore setters asking for module.exports.__esModule.
+    if (name === "__esModule") return;
 
-  for (var i = 0; i < nameCount; ++i) {
-    var name = names[i];
-
-    if (needToCheckNames &&
-        ! hasOwn.call(entry.setters, name)) {
-      continue;
-    }
+    var settersByKey = entry.setters[name];
+    if (!settersByKey) return;
 
     var value = getExportByName(entry, name);
-    var shouldCall = false;
 
-    if (!hasOwn.call(entry._lastValues, name)) {
-      entry._lastValues[name] = Object.create(null);
-    }
+    // Although we may have multiple setter functions with different keys in
+    // settersByKey, we can compute a snapshot of value and check it against
+    // entry.snapshots[name] before iterating over the individual setter
+    // functions, which is convenient because then all the setter.snapshot
+    // properties will end up referring to the same snapshot object.
+    var snapshot = updateSnapshot(entry, name, value);
 
-    var last = entry._lastValues[name];
+    Object.keys(settersByKey).forEach(key => {
+      var setter = settersByKey[key];
 
-    if (!shouldCall && name === "*") {
-      var keysToCheck = safeKeys(value);
-      var keyCount = keysToCheck.length;
-      for (var x = 0; x < keyCount; ++x) {
-        var key = keysToCheck[x];
-        // Evaluating value[key] is risky because the property might be
-        // defined by a getter function that logs a deprecation warning (or
-        // worse) when evaluated. For example, Node uses this trick to
-        // display a deprecation warning whenever crypto.createCredentials
-        // is accessed. Fortunately, when value[key] is defined by a getter
-        // function, it's enough to check whether the getter function itself
-        // has changed, since we are careful elsewhere to preserve getters
-        // rather than prematurely evaluating them.
-        if (changed(last, key, utils.valueOrGetter(value, key))) {
-          shouldCall = true;
+      // If value has not changed since the last time we broadcast it, then
+      // snapshot === entry.snapshots[name], so there's a good chance we can
+      // skip most/all of the setters that already have setter.snapshot ===
+      // snapshot. If value has changed, snapshot !== entry.snapshots[name], and
+      // we need to broadcast the new value to every setter.
+      if (setter.snapshot !== snapshot) {
+        setter.snapshot = snapshot;
+
+        // Invoke the setter function with the updated value.
+        callback(setter, name, value);
+
+        // TODO Refactor this out of the settersByKey loop, if possible.
+        var getter = entry.getters[name];
+        if (typeof getter === "function" &&
+            // Sometimes a getter function will throw because it's called
+            // before the variable it's supposed to return has been
+            // initialized, so we need to know that the getter function has
+            // run to completion at least once.
+            getter.runCount > 0 &&
+            getter.constant) {
+          // If we happen to know that this getter function has run
+          // successfully, and will never return a different value, then we
+          // can forget the corresponding setter, because we've already
+          // reported that constant value. Note that we can't forget the
+          // getter, because we need to remember the original value in case
+          // anyone tampers with entry.module.exports[name].
+          delete settersByKey[key];
         }
       }
-    } else if (!shouldCall && changed(last, name, value)) {
-      shouldCall = true;
-    }
-
-    // Only invoke the callback if the current value is
-    // different from the last value we passed to this setter.
-    // If we need to run setters for the first time even if the value didn't change,
-    // their keys should be provided to force them to be called
-    if (!shouldCall && !keysProvided) {
-      continue;
-    }
-
-    var setters = entry.setters[name];
-    if (!keysProvided) {
-      keys = Object.keys(setters);
-    }
-
-    var keyCount = keys.length;
-
-    for (var j = 0; j < keyCount; ++j) {
-      var key = keys[j];
-
-      if (keysProvided &&
-        !hasOwn.call(setters, key)) {
-        continue;
-      }
-
-      callSetterIfNecessary(setters[key], name, value, callback);
-
-      var getter = entry.getters[name];
-      if (typeof getter === "function" &&
-          // Sometimes a getter function will throw because it's called
-          // before the variable it's supposed to return has been
-          // initialized, so we need to know that the getter function has
-          // run to completion at least once.
-          getter.runCount > 0 &&
-          getter.constant) {
-        // If we happen to know that this getter function has run
-        // successfully, and will never return a different value, then we
-        // can forget the corresponding setter, because we've already
-        // reported that constant value. Note that we can't forget the
-        // getter, because we need to remember the original value in case
-        // anyone tampers with entry.module.exports[name].
-        delete setters[key];
-      }
-    }
-  }
+    });
+  });
 }
 
 function getExportByName(entry, name) {

--- a/lib/runtime/index.js
+++ b/lib/runtime/index.js
@@ -94,7 +94,7 @@ function moduleExportDefault(value) {
 function moduleExportAs(name) {
   var entry = this;
   var includeDefault = name === "*+";
-  return function (value) {
+  var setter = function (value) {
     if (name === "*" || name === "*+") {
       Object.keys(value).forEach(function (key) {
         if (includeDefault || key !== "default") {
@@ -105,6 +105,12 @@ function moduleExportAs(name) {
       entry.exports[name] = value;
     }
   };
+
+  if (name !== '*+' && name !== "*") {
+    setter.exportAs = name;
+  }
+
+  return setter;
 }
 
 // Platform-specific code should find a way to call this method whenever


### PR DESCRIPTION
This PR tries to optimize:
- Importing a module that has already been imported a large number of times. Each time the module is imported, it loops through all previously added setters to check if any need to be called. When importing `@material-ui/icons`, most of the 3 minutes reify runs is spent on this
- Changing a single exported value in a module that is imported a large number of times. Svelte has a module that most svelte components import specific functions from, and the module also exports the component instance that is being initialized. Each time svelte creates a new component instance and changes that export, reify checks every setter to see if any need to be called, even though there usually are only a couple for the modified export. In one of my apps, this almost doubles the time svelte spends when switching pages.
- Re-exporting with `export ... from 'module'`. Many large npm packages that reify is slow at importing, such as `@material-ui/icons` and `mathjs` have a large number of these. When importing `@material-ui/icons`, ~20 seconds is spent running setters for parent modules, and most of the setters re-export values.

Changes:
- Check for changes once per name instead of once per setter. As far as I can tell, the only time some setters would have different previous values than others is if some of them are new and have never been ran. It now tracks the setters that have never been called separately so it can ensure they are still run.
- When using the `export ... from 'module'` syntax, the re-exported values are not available within the module. If the re-exported value changes, there is no reason to run the other getters since their value shouldn't be affected by it. When setters are created using the shorthand to re-export, Reify now records which exports the setter modifies. When those are the only setters ran for a parent, reify only runs the parent's getters for the modified exports instead of all of them. This optimization is currently not used for export all declarations (`export * from 'module'`).

### Performance improvement:

The times are from the second run to ensure the cache is up to date. I modified the package.json files for `@material-ui/icons` and `mathjs`  in `node_modules` to enable using reify with them.

#### Importing `@material-ui/icons` in Node 14

```js
import { Web, Add } from '@material-ui/icons/esm/index.js';
```
commonjs: 3 seconds
before: 3 minutes
after: 4 seconds. ~1/3 of the extra second compared to commonjs is from reify's Node compile hook
The changes also reduces memory usage by ~12mb.

```js
import * as icons from '@material-ui/icons/esm/index.js';
```
before: 3 minutes
after: 12 seconds

Tracking changes when running getters instead of when running setters would remove the difference between this and `import { Web, Add } from '@material-ui/icons/esm/index.js';`.

#### Importing `mathjs` in Node 14
```js
require('mathjs/lib/esm');
```

commonjs: 800ms
before:  1730ms
after: 1450ms

I haven't spent enough time looking into why `mathjs` is still slow to import to find the cause. It does have some export all declarations (`export * from 'module'`) which the re-export optimizations are disabled for.