### PR TITLE
Remove code that relied on private process.binding("fs") API.

### DIFF
--- a/node/fs.js
+++ b/node/fs.js
@@ -6,7 +6,6 @@ const utils = require("../lib/utils.js");
 const zlib = require("zlib");
 
 const FastObject = require("../lib/fast-object.js");
-const SemVer = require("semver");
 
 let pendingWriteTimer = null;
 const pendingWrites = new FastObject;


### PR DESCRIPTION
Recent versions of Node.js have started to complain about this usage, logging warnings like
```
DeprecationWarning: process.binding() is deprecated. Please use public APIs instead.
```
This seems like a reasonable warning/request to me. If anyone was relying on the extra performance that these fast paths provided, feel free to comment below.