### PR TITLE
Track uninitialized setters

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -29,6 +29,8 @@ function Entry(id) {
   // Map from local names to snapshots of the corresponding local values, used
   // to determine when local values have changed and need to be re-broadcast.
   this.snapshots = Object.create(null);
+
+  this._uninitializedSetters = [];
 }
 
 var Ep = utils.setPrototypeOf(Entry.prototype, null);
@@ -101,6 +103,12 @@ Ep.addSetters = function (parent, setters, key) {
         entry.setters[name] = Object.create(null);
       }
       entry.setters[name][key] = setter;
+
+      this._uninitializedSetters.push({
+        name: name,
+        key: key,
+        setter: setter
+      });
     }
   }
 
@@ -224,7 +232,7 @@ Ep.runSetters = function (names, runNsSetter) {
   var parents;
   var parentNames;
 
-  forEachSetter(this, names, function (setter, name, value) {
+  function runSetter(setter, name, value) {
     if (parents === void 0) {
       parents = Object.create(null);
     }
@@ -252,7 +260,20 @@ Ep.runSetters = function (names, runNsSetter) {
     // The param order for setters is `value` then `name` because the `name`
     // param is only used by namespace exports.
     setter(value, name);
-  });
+  };
+
+  forEachSetter(this, names, void 0, runSetter);
+
+  if (this._uninitializedSetters.length > 0) {
+    var entry = this;
+    this._uninitializedSetters.forEach(function (config) {
+      if (!config.setter.initialized) {
+        forEachSetter(entry, [config.name], [config.key], runSetter);
+      }
+    });
+
+    this._uninitializedSetters.length = 0;
+  }
 
   if (! parents) {
     return;
@@ -280,7 +301,7 @@ Ep.runSetters = function (names, runNsSetter) {
   }
 };
 
-function updateSnapshot(entry, name, newValue) {
+function createSnapshot(entry, name, newValue) {
   var newSnapshot = Object.create(null);
   var newKeys = [];
 
@@ -313,7 +334,7 @@ function updateSnapshot(entry, name, newValue) {
     return oldSnapshot;
   }
 
-  return entry.snapshots[name] = newSnapshot;
+  return newSnapshot;
 }
 
 function normalizeSnapshotValue(value) {
@@ -325,7 +346,8 @@ function normalizeSnapshotValue(value) {
 // Invoke the given callback once for every (setter, name, value) that needs to
 // be called. Note that forEachSetter does not call any setters itself, only the
 // given callback.
-function forEachSetter(entry, names, callback) {
+function forEachSetter(entry, names, uninitializedKeys, callback) {
+  var keysProvided = uninitializedKeys !== void 0;
   if (names === void 0) {
     names = Object.keys(entry.setters);
   }
@@ -354,19 +376,34 @@ function forEachSetter(entry, names, callback) {
     // entry.snapshots[name] before iterating over the individual setter
     // functions, which is convenient because then all the setter.snapshot
     // properties will end up referring to the same snapshot object.
-    var snapshot = updateSnapshot(entry, name, value);
+    var snapshot = createSnapshot(entry, name, value);
 
-    Object.keys(settersByKey).forEach(key => {
+    var keys;
+
+    if (entry.snapshots[name] !== snapshot) {
+      keys = Object.keys(settersByKey);
+      entry.snapshots[name] = snapshot;
+    } else if (keysProvided) {
+      keys = uninitializedKeys;
+    }
+
+    if (keys === void 0) {
+      return;
+    }
+
+    keys.forEach(key => {
       var setter = settersByKey[key];
+      if (!setter) {
+        return;
+      }
+
 
       // If value has not changed since the last time we broadcast it, then
       // snapshot === entry.snapshots[name], so there's a good chance we can
       // skip most/all of the setters that already have setter.snapshot ===
       // snapshot. If value has changed, snapshot !== entry.snapshots[name], and
       // we need to broadcast the new value to every setter.
-      if (setter.snapshot !== snapshot) {
-        setter.snapshot = snapshot;
-
+        setter.initialized = true;
         // Invoke the setter function with the updated value.
         callback(setter, name, value);
 
@@ -379,7 +416,6 @@ function forEachSetter(entry, names, callback) {
           // value in case anyone tampers with entry.module.exports[name].
           delete settersByKey[key];
         }
-      }
     });
   });
 }

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -16,21 +16,31 @@ var keySalt = 0;
 function Entry(id) {
   // The canonical absolute module ID of the module this Entry manages.
   this.id = id;
+
   // The Module object this Entry manages, unknown until module.export or
   // module.link is called for the first time.
   this.module = null;
-  // Getters for local variables exported from the managed module.
-  this.getters = Object.create(null);
-  // Setters for assigning to local variables in parent modules.
-  this.setters = Object.create(null);
+
   // The normalized namespace object that importers receive when they use
   // `import * as namespace from "..."` syntax.
   this.namespace = utils.createNamespace();
+
+  // Getters for local variables exported from the managed module.
+  this.getters = Object.create(null);
+
+  // Setters for assigning to local variables in parent modules.
+  this.setters = Object.create(null);
+
+  // Map of setters added since the last broadcast (in the same shape as
+  // entry.setters[name][key]), which should receive a broadcast the next time
+  // entry.runSetters() is called, regardless of whether entry.snapshots[name]
+  // has changed or not. Once called, setters are removed from this.newSetters,
+  // but remain in this.setters.
+  this.newSetters = Object.create(null);
+
   // Map from local names to snapshots of the corresponding local values, used
   // to determine when local values have changed and need to be re-broadcast.
   this.snapshots = Object.create(null);
-
-  this._uninitializedSetters = [];
 }
 
 var Ep = utils.setPrototypeOf(Entry.prototype, null);
@@ -99,16 +109,12 @@ Ep.addSetters = function (parent, setters, key) {
 
     if (typeof setter === "function") {
       setter.parent = parent;
-      if (! (name in entry.setters)) {
-        entry.setters[name] = Object.create(null);
-      }
-      entry.setters[name][key] = setter;
-
-      this._uninitializedSetters.push({
-        name: name,
-        key: key,
-        setter: setter
-      });
+      // Store the setter as entry.setters[name][key], and also record it
+      // temporarily in entry.newSetters, so we can be sure to run it when we
+      // call entry.runSetters(names) below, even though entry.snapshots[name]
+      // likely will not have changed for this name.
+      utils.ensureObjectProperty(entry.setters, name)[key] = setter;
+      utils.ensureObjectProperty(entry.newSetters, name)[key] = setter;
     }
   }
 
@@ -232,7 +238,7 @@ Ep.runSetters = function (names, runNsSetter) {
   var parents;
   var parentNames;
 
-  function runSetter(setter, name, value) {
+  forEachSetter(this, names, function (setter, name, value) {
     if (parents === void 0) {
       parents = Object.create(null);
     }
@@ -260,20 +266,7 @@ Ep.runSetters = function (names, runNsSetter) {
     // The param order for setters is `value` then `name` because the `name`
     // param is only used by namespace exports.
     setter(value, name);
-  };
-
-  forEachSetter(this, names, void 0, runSetter);
-
-  if (this._uninitializedSetters.length > 0) {
-    var entry = this;
-    this._uninitializedSetters.forEach(function (config) {
-      if (!config.setter.initialized) {
-        forEachSetter(entry, [config.name], [config.key], runSetter);
-      }
-    });
-
-    this._uninitializedSetters.length = 0;
-  }
+  });
 
   if (! parents) {
     return;
@@ -343,11 +336,38 @@ function normalizeSnapshotValue(value) {
   return value;
 }
 
+// Obtain an array of keys in entry.setters[name] for which we need to run a
+// setter function. If successful, entry.snapshot[name] will be updated and/or
+// entry.newSetters[name] will be removed, so the returned keys will not be
+// returned again until after the snapshot changes again. If the snapshot hasn't
+// changed and there aren't any entry.newSetters[name] keys, this function
+// returns undefined, to avoid allocating an empty array in the common case.
+function consumeKeysGivenSnapshot(entry, name, snapshot) {
+  if (entry.snapshots[name] !== snapshot) {
+    entry.snapshots[name] = snapshot;
+    // Since the keys of entry.newSetters[name] are a subset of those of
+    // entry.setters[name], we can consume entry.newSetters[name] here too.
+    delete entry.newSetters[name];
+    return Object.keys(entry.setters[name]);
+  }
+
+  // If new setters have been added to entry.setters (and thus also to
+  // entry.newSetters) since we last recorded entry.snapshots[name], we need to
+  // run those setters (for the first time) in order to consider them up-to-date
+  // with respect to entry.snapshots[name].
+  var news = entry.newSetters[name];
+  var newKeys = news && Object.keys(news);
+  if (newKeys && newKeys.length) {
+    // Consume the new keys so we don't consider them again.
+    delete entry.newSetters[name];
+    return newKeys;
+  }
+}
+
 // Invoke the given callback once for every (setter, name, value) that needs to
 // be called. Note that forEachSetter does not call any setters itself, only the
 // given callback.
-function forEachSetter(entry, names, uninitializedKeys, callback) {
-  var keysProvided = uninitializedKeys !== void 0;
+function forEachSetter(entry, names, callback) {
   if (names === void 0) {
     names = Object.keys(entry.setters);
   }
@@ -377,22 +397,8 @@ function forEachSetter(entry, names, uninitializedKeys, callback) {
     // functions
     var snapshot = createSnapshot(entry, name, value);
 
-    var keys;
-
-    // If value has not changed since the last time we broadcast it, then
-    // snapshot === entry.snapshots[name], and only uninitialized setters need
-    // to be run. If value has changed, snapshot !== entry.snapshots[name], and
-    // we need to broadcast the new value to every setter.
-    if (entry.snapshots[name] !== snapshot) {
-      keys = Object.keys(settersByKey);
-      entry.snapshots[name] = snapshot;
-    } else if (keysProvided) {
-      keys = uninitializedKeys;
-    }
-
-    if (keys === void 0) {
-      return;
-    }
+    var keys = consumeKeysGivenSnapshot(entry, name, snapshot);
+    if (keys === void 0) return;
 
     keys.forEach(key => {
       var setter = settersByKey[key];
@@ -400,7 +406,6 @@ function forEachSetter(entry, names, uninitializedKeys, callback) {
         return;
       }
 
-      setter.initialized = true;
       // Invoke the setter function with the updated value.
       callback(setter, name, value);
 

--- a/lib/runtime/entry.js
+++ b/lib/runtime/entry.js
@@ -287,7 +287,7 @@ Ep.runSetters = function (names, runNsSetter) {
 
   for (var i = 0; i < parentIDCount; ++i) {
     // What happens if parents[parentIDs[id]] === module, or if
-    // longer cycles exist in the parent chain? Thanks to our setter.last
+    // longer cycles exist in the parent chain? Thanks to our snapshot
     // bookkeeping above, the runSetters broadcast will only proceed
     // as far as there are any actual changes to report.
     var parent = parents[parentIDs[i]];
@@ -374,12 +374,15 @@ function forEachSetter(entry, names, uninitializedKeys, callback) {
     // Although we may have multiple setter functions with different keys in
     // settersByKey, we can compute a snapshot of value and check it against
     // entry.snapshots[name] before iterating over the individual setter
-    // functions, which is convenient because then all the setter.snapshot
-    // properties will end up referring to the same snapshot object.
+    // functions
     var snapshot = createSnapshot(entry, name, value);
 
     var keys;
 
+    // If value has not changed since the last time we broadcast it, then
+    // snapshot === entry.snapshots[name], and only uninitialized setters need
+    // to be run. If value has changed, snapshot !== entry.snapshots[name], and
+    // we need to broadcast the new value to every setter.
     if (entry.snapshots[name] !== snapshot) {
       keys = Object.keys(settersByKey);
       entry.snapshots[name] = snapshot;
@@ -397,25 +400,19 @@ function forEachSetter(entry, names, uninitializedKeys, callback) {
         return;
       }
 
+      setter.initialized = true;
+      // Invoke the setter function with the updated value.
+      callback(setter, name, value);
 
-      // If value has not changed since the last time we broadcast it, then
-      // snapshot === entry.snapshots[name], so there's a good chance we can
-      // skip most/all of the setters that already have setter.snapshot ===
-      // snapshot. If value has changed, snapshot !== entry.snapshots[name], and
-      // we need to broadcast the new value to every setter.
-        setter.initialized = true;
-        // Invoke the setter function with the updated value.
-        callback(setter, name, value);
-
-        if (alreadyCalledConstantGetter) {
-          // If we happen to know this getter function has run successfully
-          // (getter.runCount > 0), and will never return a different value
-          // (getter.constant), then we can forget the corresponding setter,
-          // because we've already reported that constant value. Note that we
-          // can't forget the getter, because we need to remember the original
-          // value in case anyone tampers with entry.module.exports[name].
-          delete settersByKey[key];
-        }
+      if (alreadyCalledConstantGetter) {
+        // If we happen to know this getter function has run successfully
+        // (getter.runCount > 0), and will never return a different value
+        // (getter.constant), then we can forget the corresponding setter,
+        // because we've already reported that constant value. Note that we
+        // can't forget the getter, because we need to remember the original
+        // value in case anyone tampers with entry.module.exports[name].
+        delete settersByKey[key];
+      }
     });
   });
 }

--- a/lib/runtime/utils.js
+++ b/lib/runtime/utils.js
@@ -91,6 +91,12 @@ function isObjectLike(value) {
 
 exports.isObjectLike = isObjectLike;
 
+exports.ensureObjectProperty = function (object, propertyName) {
+  return hasOwn.call(object, propertyName)
+    ? object[propertyName]
+    : object[propertyName] = Object.create(null);
+};
+
 function createNamespace() {
   var namespace = Object.create(null);
 


### PR DESCRIPTION
Re-implements one of the optimizations from https://github.com/benjamn/reify/pull/246 that was removed.

Reduces the time spent by `runSetters` when running `import { Web, Add } from '@material-ui/icons/esm/index.js';` from ~15-20 seconds down to less than 1. In the [Svelte example](https://github.com/benjamn/reify/pull/246#issuecomment-873298064), this would reduce the time spent by `runSetters` to around 4ms from the current 32ms.