### PR TITLE
Allow export.__esModule to be overwritten

### DIFF
--- a/lib/runtime/utils.js
+++ b/lib/runtime/utils.js
@@ -70,7 +70,7 @@ function setESModule(exported) {
         configurable: true,
         enumerable: false,
         value: true,
-        writable: false
+        writable: true
       });
     }
   }

--- a/test/misc-tests.js
+++ b/test/misc-tests.js
@@ -92,3 +92,9 @@ describe("object-like module.exports", () => {
     assert.strictEqual(typeof forEach, "function");
   });
 });
+
+describe("setEsModule", () => {
+  it("should not error if __esModule is set before or after setEsModule is called", () => {
+    import './misc/__esModule-export-after';
+  });
+});

--- a/test/misc/__esModule-export-after.js
+++ b/test/misc/__esModule-export-after.js
@@ -1,0 +1,3 @@
+import './__esModule-export-before.js';
+
+exports.__esModule = true

--- a/test/misc/__esModule-export-before.js
+++ b/test/misc/__esModule-export-before.js
@@ -1,0 +1,10 @@
+Object.defineProperty(module.exports, '__esModule', {
+  configurable: false,
+  enumerable: false,
+  value: true,
+  writable: false
+});
+
+module.export({
+  a: () => 5
+});


### PR DESCRIPTION
Avoids an error if the file was already compiled by babel, and babel added the line `exports.__esModule = true`.
Fixes https://github.com/meteor/meteor/issues/12035